### PR TITLE
Use findLastIndex instead of array.lastIndexOf

### DIFF
--- a/lib/collector.js
+++ b/lib/collector.js
@@ -58,7 +58,7 @@ class Collector {
 
   onMessage (message) {
     var runs = message.payload.status.runs;
-    var lastNonRetry = runs.lastIndexOf(run => {
+    var lastNonRetry = _.findLastIndex(runs, run => {
       return run.reasonCreated !== 'retry';
     });
     if (lastNonRetry === -1) {


### PR DESCRIPTION
Appears lastIndexOf doesn't work with a predicate..


I think I encouraged you to use it... Sorry, but I think `_.findLastIndex` will work..
Please review, test and deploy...