### PR TITLE
Bug 1294180: fix pending calculation of cancelled/exception tasks

### DIFF
--- a/test/collect_test.js
+++ b/test/collect_test.js
@@ -76,5 +76,9 @@ suite('stats-collection', () => {
     });
     assert(monitor.measures['tasks.stats-dummy.running']);
     assert.equal(monitor.measures['tasks.stats-dummy.running'].length, 2);
+
+    col.flush();
+
+    assert(monitor.measures['tasks.stats-dummy.pending']);
   });
 });


### PR DESCRIPTION
Based on a local run, I expect this will get us much more accurate current pending times.  There will still be some sparsity when dynos restart, but I don't think that should affect things too much.