### PR TITLE
Listener test only runs when clientId is set

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -1,10 +1,10 @@
 defaults:
   app:
-    queueName: !env QUEUE_NAME
+    queueName:
   pulse:
-    username: !env PULSE_USERNAME
-    password: !env PULSE_PASSWORD
+    username:
+    password:
   taskcluster:
     credentials:
-      clientId:     !env TASKCLUSTER_CLIENT_ID
-      accessToken:  !env TASKCLUSTER_ACCESS_TOKEN
+      clientId:
+      accessToken:

--- a/test/listener_test.js
+++ b/test/listener_test.js
@@ -1,87 +1,97 @@
 suite('TaskListener', () => {
-  test('listens', async () => {
-    var debug = require('debug')('test:test');
-    var assert = require('assert');
-    var TaskListener = require('../lib/listener.js');
-    var slugid = require('slugid');
-    var taskcluster = require('taskcluster-client');
-    var base = require('taskcluster-base');
-    var monitoring = require('taskcluster-lib-monitor');
+  var debug = require('debug')('test:test');
+  var assert = require('assert');
+  var TaskListener = require('../lib/listener.js');
+  var slugid = require('slugid');
+  var taskcluster = require('taskcluster-client');
+  var base = require('taskcluster-base');
+  var monitoring = require('taskcluster-lib-monitor');
 
+  let listenerTest = async () => {
     let cfg = base.config({profile: 'test'});
+    if (cfg.taskcluster.credentials.clientId !== undefined) {
+      return test('listens', async() => {
+        var taskdefn = {
+          provisionerId: 'stats-provisioner',
+          workerType: 'stats-dummy',
+          payload: {},
+          created: taskcluster.fromNowJSON(),
+          deadline: taskcluster.fromNowJSON('2 hours'),
+          metadata: {
+            name: 'Testing!',
+            description: 'testing?',
+            owner: 'eggylv999@gmail.com',
+            source: 'https://github.com/taskcluster/taskcluster-stats-collector',
+          },
+        };
 
-    var taskdefn = {
-      provisionerId: 'stats-provisioner',
-      workerType: 'stats-dummy',
-      payload: {},
-      created: taskcluster.fromNowJSON(),
-      deadline: taskcluster.fromNowJSON('2 hours'),
-      metadata: {
-        name: 'Testing!',
-        description: 'testing?',
-        owner: 'eggylv999@gmail.com',
-        source: 'https://github.com/taskcluster/taskcluster-stats-collector',
-      },
-    };
+        console.log(JSON.stringify(cfg));
 
-    assert(cfg.pulse, 'pulse credentials required');
-    assert(cfg.taskcluster, 'taskcluster credentials required');
+        assert(cfg.pulse, 'pulse credentials required');
+        assert(cfg.taskcluster, 'taskcluster credentials required');
 
-    let monitor = await monitoring({
-      project: 'tc-stats-collector',
-      credentials: {clientId: 'fake', accessToken: 'alsofake'},
-      mock: true,
-    });
+        let monitor = await monitoring({
+          project: 'tc-stats-collector',
+          credentials: {clientId: 'fake', accessToken: 'alsofake'},
+          mock: true,
+        });
 
-    let listener = new TaskListener({
-      credentials: cfg.pulse,
-      queueName: undefined,
-      routingKey: {
-        provisionerId: 'stats-provisioner',
-      },
-      monitor,
-    });
+        let listener = new TaskListener({
+          credentials: cfg.pulse,
+          queueName: undefined,
+          routingKey: {
+            provisionerId: 'stats-provisioner',
+          },
+          monitor,
+        });
 
-    let task_messages = [];
-    listener.on('task-message', ({action}) => task_messages.push(action));
-    await listener.start();
+        let task_messages = [];
+        listener.on('task-message', ({action}) => task_messages.push(action));
+        await listener.start();
 
-    var id = slugid.v4();
-    var queue = new taskcluster.Queue({
-      credentials: cfg.taskcluster.credentials,
-    });
+        var id = slugid.v4();
+        var queue = new taskcluster.Queue({
+          credentials: cfg.taskcluster.credentials,
+        });
 
-    let result = await queue.createTask(id, taskdefn);
-    assert(result);
-    debug('task created');
+        let result = await queue.createTask(id, taskdefn);
+        assert(result);
+        debug('task created');
 
-    await queue.claimTask(id, 0, {
-      workerGroup:    'my-worker-group',
-      workerId:       'my-worker',
-    });
-    debug('task claimed');
+        await queue.claimTask(id, 0, {
+          workerGroup:    'my-worker-group',
+          workerId:       'my-worker',
+        });
+        debug('task claimed');
 
-    await queue.reportException(id, 0, {reason: 'worker-shutdown'});
-    debug('task exception');
+        await queue.reportException(id, 0, {reason: 'worker-shutdown'});
+        debug('task exception');
 
-    await queue.claimTask(id, 1, {
-      workerGroup:    'my-worker-group',
-      workerId:       'my-worker',
-    });
-    debug('task claimed again');
+        await queue.claimTask(id, 1, {
+          workerGroup:    'my-worker-group',
+          workerId:       'my-worker',
+        });
+        debug('task claimed again');
 
-    await queue.reportCompleted(id, 1);
-    debug('task completed');
+        await queue.reportCompleted(id, 1);
+        debug('task completed');
 
-    await listener.close();
+        await listener.close();
 
-    assert.deepEqual(task_messages, [
-      'task-pending',
-      'task-running',
-      'task-pending',
-      'task-running',
-      'task-completed',
-    ]);
-  });
+        assert.deepEqual(task_messages, [
+          'task-pending',
+          'task-running',
+          'task-pending',
+          'task-running',
+          'task-completed',
+        ]);
+      });
+    }
+
+    console.warn('Skipping Listening Test: Need clientId in configuration');
+    return test.skip('listens', async() => { });
+  };
+
+  listenerTest();
 });
 

--- a/test/listener_test.js
+++ b/test/listener_test.js
@@ -9,7 +9,7 @@ suite('TaskListener', () => {
 
   let listenerTest = async () => {
     let cfg = base.config({profile: 'test'});
-    if (cfg.taskcluster.credentials.clientId !== undefined) {
+    if (cfg.taskcluster.credentials.clientId) {
       return test('listens', async() => {
         var taskdefn = {
           provisionerId: 'stats-provisioner',
@@ -24,8 +24,6 @@ suite('TaskListener', () => {
             source: 'https://github.com/taskcluster/taskcluster-stats-collector',
           },
         };
-
-        console.log(JSON.stringify(cfg));
 
         assert(cfg.pulse, 'pulse credentials required');
         assert(cfg.taskcluster, 'taskcluster credentials required');

--- a/user-config-example.yml
+++ b/user-config-example.yml
@@ -1,8 +1,10 @@
 defaults:
+  app:
+    queueName: !env QUEUE_NAME
   pulse:
-    username: '...'
-    password: '...'
+    username: !env PULSE_USERNAME
+    password: !env PULSE_PASSWORD
   taskcluster:
     credentials:
-      clientId: '...'
-      accessToken: '...'
+      clientId:     !env TASKCLUSTER_CLIENT_ID
+      accessToken:  !env TASKCLUSTER_ACCESS_TOKEN


### PR DESCRIPTION
Wrote a wrapper around the TaskListener listen test.

This test will be only run when **clientId** is truthy in **config.yml**.
If the clientId is not set, then the test will be seen as skipped.
