### PR TITLE
Bug 1306130: add tc-lib-docs to tc-stats-collector

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,15 +9,15 @@
     "install": "npm run compile"
   },
   "dependencies": {
-    "babel-runtime": "^6.0.0",
-    "babel-eslint": "^6.0.2",
     "babel-compile": "^1.0.0",
     "babel-core": "^6.1.21",
+    "babel-eslint": "^6.0.2",
     "babel-plugin-syntax-async-functions": "^6.5.0",
     "babel-plugin-transform-async-to-generator": "^6.5.0",
     "babel-plugin-transform-runtime": "^6.5.2",
     "babel-plugin-transform-strict-mode": "^6.6.5",
     "babel-preset-es2015": "^6.6.0",
+    "babel-runtime": "^6.0.0",
     "debug": "^2.1.3",
     "lodash": "^3.6.0",
     "mocha": "^2.4.5",
@@ -25,6 +25,7 @@
     "slugid": "1.0.3",
     "taskcluster-base": "^0.12.2",
     "taskcluster-client": "^0.23.16",
+    "taskcluster-lib-docs": "^3.0.2",
     "taskcluster-lib-monitor": "^0.2.1",
     "tc-rules": "^3.0.1"
   },

--- a/src/main.js
+++ b/src/main.js
@@ -1,6 +1,7 @@
 var TaskListener  = require('./listener.js');
 var monitoring = require('taskcluster-lib-monitor');
 let base = require('taskcluster-base');
+let docs = require('taskcluster-lib-docs');
 
 let load = base.loader({
   cfg: {
@@ -24,9 +25,19 @@ let load = base.loader({
     }),
   },
 
+  docs: {
+    requires: ['cfg'],
+    setup: ({cfg}) => docs.documenter({
+      credentials: cfg.taskcluster.credentials,
+      project: 'stats-collector',
+      tier: 'core',
+      publish: true,
+    }),
+  },
+
   server: {
-    requires: ['listener', 'monitor', 'cfg'],
-    setup: async ({listener, monitor, cfg}) => {
+    requires: ['listener', 'monitor', 'cfg', 'docs'],
+    setup: async ({listener, monitor, cfg, docs}) => {
       // set up the various collectors
       require('./running')({monitor, listener});
       require('./pending')({monitor, listener});


### PR DESCRIPTION
Brian, did I forget anything here?  There's not much documentation beyond the README.md for the moment, but I'd like to see that working.

Do I need to loop back to taskcluster-docs to remove the README index file there?