### PR TITLE
Bug1316677: do not record pending stats for dummy workers, do record provisionerId

### DIFF
--- a/src/collector/pending.js
+++ b/src/collector/pending.js
@@ -12,6 +12,17 @@ const CHECK_INTERVAL = 120; // seconds
 // thresholds for pending tasks.
 const MIN_CHECK_AGE = 300; // seconds
 
+// useless test provisioners
+const IGNORE_PROVISIONERS = [
+  'test-provisioner',
+  'dummy-test-provisioner',
+  'no-provisioner',
+  'no-provisioning-nope',
+  'test-dummy-provisioner',
+  'tc-worker-provisioner',
+  'stats-provisioner',
+];
+
 collectorManager.collector({
   name: 'pending',
   requires: ['monitor', 'listener', 'queue', 'clock'],
@@ -101,6 +112,10 @@ collectorManager.collector({
 
   listener.on('task-message', ({action, payload}) => {
     try {
+      // skip some very noisy, useless provisioners
+      if (IGNORE_PROVISIONERS.indexOf(payload.status.provisionerId) !== -1) {
+        return;
+      }
       let taskKey = `${payload.status.taskId}/${payload.runId}`;
       let workerType = `${payload.status.provisionerId}.${payload.status.workerType}`;
       let isPending = action === 'task-pending';

--- a/src/collector/pending.js
+++ b/src/collector/pending.js
@@ -69,6 +69,8 @@ collectorManager.collector({
     for (let workerType of Object.keys(readyWorkerTypes)) {
       let {taskKey, scheduled} = earliest(workerType, now);
       let waiting = taskKey ? now - scheduled : 0;
+      let oldWorkerType = workerType.split('.')[1];
+      monitor.measure(`tasks.${oldWorkerType}.pending`, waiting); // old measure
       monitor.measure(`tasks.${workerType}.pending`, waiting);
     }
   };
@@ -100,7 +102,7 @@ collectorManager.collector({
   listener.on('task-message', ({action, payload}) => {
     try {
       let taskKey = `${payload.status.taskId}/${payload.runId}`;
-      let workerType = payload.status.workerType;
+      let workerType = `${payload.status.provisionerId}.${payload.status.workerType}`;
       let isPending = action === 'task-pending';
       let scheduled = payload.status.runs[payload.runId].scheduled;
 


### PR DESCRIPTION
This temporarily continues to write out the existing statistics.  After a week or two we can switch the dashboards to use the new stats, and then turn off the old.

The whitelist of dummy provisioners makes me sad, but I don't think cleaning that up is a good use of time right now.