### PR TITLE
Service levels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 collect.conf.json
 .env
 user-config.yml
+yarn.lock

--- a/README.md
+++ b/README.md
@@ -2,22 +2,36 @@
 
 [![Build Status](https://travis-ci.org/taskcluster/taskcluster-stats-collector.svg?branch=master)](https://travis-ci.org/taskcluster/taskcluster-stats-collector)
 
-Reads TaskCluster messages off pulse and creates relevant statistics.
+Manages statistics collection for the TaskCluster team.
 
 # Data Collected
 
-## Running Tasks
+Data are collected by "collectors"
+
+## `running` -- Running Tasks
 
 * `tasks.<workerType>.resolved.<reasonResolved>` measures the time, in
   milliseconds, to resolve task with the given reason in the given workerType.
   Tasks are only measured when they are resolved, so this does not include
   times for running tasks.
 
-## Pending Tasks
+## `pending` -- Pending Tasks
 
 * `tasks.<workerType>.pending` measures the time that each task is pending.
   Tasks are measured constantly, even if they are still pending, making this a
   valid measure of the current pending time.
+
+# Running locally
+
+To run the server locally, compile (`npm run compile`) and then execute:
+
+```
+NODE_ENV=development DEBUG=* node lib/main server
+```
+
+Note that you can also set ONLY_COLLECTOR to the name of a single collector to
+run only that collector.
+
 
 # Testing
 

--- a/config.yml
+++ b/config.yml
@@ -1,4 +1,6 @@
 defaults:
+  signalfx:
+    apiToken: !env SIGNALFX_API_TOKEN
   pulse:
     username: !env PULSE_USERNAME
     password: !env PULSE_PASSWORD

--- a/package.json
+++ b/package.json
@@ -8,6 +8,9 @@
     "pretest": "npm run compile",
     "install": "npm run compile"
   },
+  "devDependencies": {
+    "assume": "^1.4.1"
+  },
   "dependencies": {
     "babel-compile": "^2.0.0",
     "babel-preset-taskcluster": "^3.0.0",
@@ -18,6 +21,7 @@
     "mocha-eslint": "^2.0.1",
     "signalfx": "^4.0.0",
     "slugid": "1.0.3",
+    "superagent": "^2.3.0",
     "taskcluster-client": "^0.23.16",
     "taskcluster-lib-docs": "^3.0.2",
     "taskcluster-lib-loader": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -16,10 +16,11 @@
     "lodash": "^3.6.0",
     "mocha": "^2.4.5",
     "mocha-eslint": "^2.0.1",
+    "signalfx": "^4.0.0",
     "slugid": "1.0.3",
-    "taskcluster-lib-loader": "1.1.0",
     "taskcluster-client": "^0.23.16",
     "taskcluster-lib-docs": "^3.0.2",
+    "taskcluster-lib-loader": "1.1.0",
     "taskcluster-lib-monitor": "^0.2.1",
     "tc-rules": "^3.0.1",
     "typed-env-config": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "babel-preset-taskcluster": "^3.0.0",
     "babel-runtime": "^6.6.1",
     "debug": "^2.1.3",
+    "from": "^0.1.3",
     "lodash": "^3.6.0",
     "mocha": "^2.4.5",
     "mocha-eslint": "^2.0.1",

--- a/src/clock.js
+++ b/src/clock.js
@@ -1,4 +1,5 @@
 import debugModule from 'debug';
+import _ from 'lodash';
 
 const debug = debugModule('clock');
 
@@ -45,6 +46,11 @@ class Clock {
         await new Promise(resolve => setTimeout(resolve, interval));
       }
     }, interval);
+  }
+
+  // like lodash's throttle, but without throttling tests
+  throttle () {
+    return _.throttle.apply(_, arguments);
   }
 };
 

--- a/src/clock.js
+++ b/src/clock.js
@@ -12,6 +12,25 @@ class Clock {
     return new Date().getTime();
   }
 
+  // Run fn at the given time
+  // TODO: test
+  at (name, when, fn) {
+    let delay = when - new Date();
+    if (delay < 0) {
+      delay = 0;
+    }
+
+    setTimeout(async () => {
+      debug('Running ' + name);
+      try {
+        await fn();
+      } catch (err) {
+        this.monitor.reportError(err);
+        console.log('%s failed: %s', name, err);
+      }
+    }, delay);
+  }
+
   // Run fn periodically, whether async or not, surviving errors
   periodically (interval, name, fn) {
     setTimeout(async () => {

--- a/src/collector/running.js
+++ b/src/collector/running.js
@@ -5,8 +5,8 @@ collectorManager.collector({
   name: 'running',
   requires: ['monitor', 'listener'],
   // support emitting via statsum or directly as a time series
-}, ({monitor, listener, debug}) => {
-  listener.on('task-message', ({action, payload}) => {
+}, function () {
+  this.listener.on('task-message', ({action, payload}) => {
     try {
       if (action === 'task-pending' || action === 'task-running') {
         return;
@@ -24,12 +24,12 @@ collectorManager.collector({
         if (run.reasonResolved !== 'deadline-exceeded') {
           var started = new Date(run.started);
           var resolved = new Date(run.resolved);
-          monitor.measure(`tasks.${workerType}.running`, resolved - started);
+          this.monitor.measure(`tasks.${workerType}.running`, resolved - started);
         }
-        monitor.count(`tasks.${workerType}.resolved.${run.reasonResolved}`);
+        this.monitor.count(`tasks.${workerType}.resolved.${run.reasonResolved}`);
       });
     } catch (err) {
-      debug('Failed to process message %s with error: %s, as JSON: %j',
+      this.debug('Failed to process message %s with error: %s, as JSON: %j',
             action, err, err, err.stack);
     }
   });

--- a/src/collector/sli-gecko-pending.js
+++ b/src/collector/sli-gecko-pending.js
@@ -1,0 +1,55 @@
+import collectorManager from '../collectormanager';
+import {Transform} from 'stream';
+import {signalFxMetricStream, metricLoggerStream, multiplexMetricStreams} from '../metricstream';
+import _ from 'lodash';
+
+const HOUR = 1000 * 60 * 60;
+const FIVE_MINUTE = 1000 * 5 * 60;
+
+const TEST_WORKERTYPES = [
+  'desktop-test',
+  'desktop-test-large',
+  'desktop-test-xlarge',
+];
+
+const maxTransform = () => new Transform({
+  objectMode: true,
+  transform(chunk, enc, callback) {
+    chunk.value = _.max(chunk.value);
+    callback(null, chunk);
+  },
+});
+
+collectorManager.collector({
+  name: 'sli.gecko.pending.test',
+  requires: ['monitor', 'clock', 'signalFxRest'],
+  // support emitting via statsum or directly as a time series
+}, function () {
+  const inputs = TEST_WORKERTYPES.map(workerType => {
+    return {
+      name: workerType,
+      stream: signalFxMetricStream({
+        query: `sf_metric:tc-stats-collector.tasks.aws-provisioner-v1.${workerType}.pending.5m.p95`,
+        resolution: '5m',
+        start: this.clock.msec() - 600 * 1000, // get some history; TODO: go as far back as required to backfill
+        clock: this.clock,
+        signalFxRest: this.signalFxRest,
+      }),
+    };
+  });
+
+  inputs.forEach(s => s.stream.on('error', err => console.error(err)));
+
+  // multiplex those streams together
+  const mux = multiplexMetricStreams({
+    streams: inputs,
+    clock: this.clock,
+  });
+
+  // transform it by taking the maximum
+  const max = maxTransform();
+  mux.pipe(max);
+
+  // and log the result
+  max.pipe(metricLoggerStream('mux'));
+});

--- a/src/collectormanager.js
+++ b/src/collectormanager.js
@@ -82,11 +82,20 @@ class CollectorManager extends EventEmitter {
    * a `collectors` component that loads them all.
    */
   components () {
-    // TODO: support only loading some, if process.env.COLLECTORS is set (for
-    // use in development)
+    // support only loading only one collector, for development
+    let collectors = this.collectors;
+
+    if (process.env.ONLY_COLLECTOR) {
+      const collector = find(collectors, {name: process.env.ONLY_COLLECTOR});
+      if (!collector) {
+        throw new Error(`Collector ${process.env.ONLY_COLLECTOR} not found`);
+      }
+      collectors = [collector];
+    }
+
     const components = {
       collectors: {
-        requires: this.collectors.map(({_fullname}) => _fullname),
+        requires: collectors.map(({_fullname}) => _fullname),
         setup: () => null,
       },
     };

--- a/src/collectormanager.js
+++ b/src/collectormanager.js
@@ -1,6 +1,7 @@
 import path from 'path';
 import fs from 'fs';
 import debug from 'debug';
+import {find} from 'lodash';
 var EventEmitter = require('events');
 
 /**
@@ -66,6 +67,9 @@ class CollectorManager extends EventEmitter {
   collector (options, setup) {
     if (!options.name) {
       throw new Error('Collector must have a name');
+    }
+    if (find(this.collectors, {name: options.name})) {
+      throw new Error('Collector must have a unique name');
     }
     options._fullname = `collector.${options.name}`;
     options._setup = setup;

--- a/src/main.js
+++ b/src/main.js
@@ -7,6 +7,7 @@ let collectorManager = require('./collectormanager');
 let taskcluster = require('taskcluster-client');
 let signalfx = require('signalfx');
 import Clock from './clock';
+import SignalFxRest from './signalfx-rest';
 
 collectorManager.setup();
 
@@ -45,7 +46,12 @@ let load = loader(Object.assign({
 
   ingest: {
     requires: ['cfg'],
-    setup: async ({cfg}) => new signalfx.Ingest(cfg.signalfx.apiToken),
+    setup: ({cfg}) => new signalfx.Ingest(cfg.signalfx.apiToken),
+  },
+
+  signalFxRest: {
+    requires: ['cfg'],
+    setup: ({cfg}) => new SignalFxRest(cfg.signalfx.apiToken),
   },
 
   docs: {

--- a/src/main.js
+++ b/src/main.js
@@ -5,6 +5,7 @@ let docs = require('taskcluster-lib-docs');
 let config = require('typed-env-config');
 let collectorManager = require('./collectormanager');
 let taskcluster = require('taskcluster-client');
+let signalfx = require('signalfx');
 import Clock from './clock';
 
 collectorManager.setup();
@@ -40,6 +41,11 @@ let load = loader(Object.assign({
   queue: {
     requires: [],
     setup: () => new taskcluster.Queue(),
+  },
+
+  ingest: {
+    requires: ['cfg'],
+    setup: async ({cfg}) => new signalfx.Ingest(cfg.signalfx.apiToken),
   },
 
   docs: {

--- a/src/metricstream.js
+++ b/src/metricstream.js
@@ -1,0 +1,283 @@
+import {Writable} from 'stream';
+import from from 'from';
+import _ from 'lodash';
+import debugModule from 'debug';
+
+const HOUR = 1000 * 60 * 60;
+
+/**
+ *
+ * A metric stream is an object stream that produces data points from the given
+ * metric, starting at the given time and continuing on until it runs "live".
+ *
+ * The stream objects are datapoints:
+ * {
+ *   ts,      // milliseconds
+ *   value,   // value of the datapoint at ts
+ *   live,    // true if this is a "live" datapoint (not historical)
+ * }
+ *
+ * Note that "live" datapoints may still have a delay of a few seconds (that is,
+ * `ts` may be a few seconds in the past) due to message propagation delays, polling,
+ * etc.
+ *
+ * Metric streams emit a "live" message and set their `live` property true
+ * after the last historical datapoint has been pushed into the stream.  Note
+ * that events and stream data are not synchronized, so this event may arrive
+ * before all buffered historical data is consumed.
+ */
+
+const RESOLUTIONS = {
+  '5s': 5 * 1000,
+  '1m': 60 * 1000,
+  '5m': 5 * 60 * 1000,
+  '1h': 60 * 60 * 1000,
+};
+
+/**
+ * Return a metric stream for the metric identified by the given query, starting
+ * at `start` and with the given resolution.  The `clock` and `signalFxRest` options
+ * should come from the loader components of the same name.
+ *
+ * Resolution must be one of `5s`, `1m`, `5m`, '1h'.
+ */
+export const signalFxMetricStream = ({query, resolution, start, clock, signalFxRest}) => {
+  let latestDatapoint = start;
+  let liveData = false;
+
+  // see comments on waking up to query the next datapoint, below
+  const DELAY_REDUCTION = 100;
+  const BACKOFF_START = 500;
+  const BACKOFF_FACTOR = 1.5;
+  let delay = 1000; // starting guess
+  let backoff = BACKOFF_START;
+
+  const resolutionMs = RESOLUTIONS[resolution];
+  if (!resolutionMs) {
+    throw new Error(`invalid resolution ${resolution}`);
+  }
+
+  const fetch = async function () {
+    const now = clock.msec();
+
+    // start back a few seconds to allow slop on signalFx's side
+    let startMs = latestDatapoint - 5000; 
+
+    let endMs = latestDatapoint + HOUR;
+    if (endMs > now) {
+      endMs = now;
+    }
+
+    (await signalFxRest.timeserieswindow({
+      query: query,
+      startMs, endMs,
+      resolution: resolutionMs,
+    })).forEach(dp => {
+      // skip if we've seen this datapoint before
+      if (dp[0] <= latestDatapoint) {
+        return;
+      }
+      latestDatapoint = dp[0];
+      this.emit('data', {ts: dp[0], value: dp[1], live: liveData});
+      if (liveData) {
+        delay = now - latestDatapoint;
+        backoff = BACKOFF_START;
+      }
+    });
+
+    // if we are up to the current time, then remaining samples will be "live"
+    if (endMs === now) {
+      if (!liveData) {
+        this.live = true;
+        this.emit('live');
+      }
+      liveData = true;
+    }
+
+    // if we're live and there's no more deta, assume the next datapoint will
+    // be here about the resolution + delay after the last datapoint; failing
+    // that, poll with a slow backoff.  This should occasionally re-try quickly,
+    // as that is the only way to reduce the delay.  This is a guessing game,
+    // but is pretty key to getting timely results.
+    if (liveData) {
+      const wakeup = latestDatapoint + resolutionMs + delay - DELAY_REDUCTION;
+      this.pause();
+      // TODO: clock.at
+      setTimeout(() => this.resume(), (wakeup > now) ? wakeup - now : backoff);
+      backoff = backoff * 1.5;
+    }
+  };
+
+  const stream = from(function (count, next) {
+    let errBackoff = 60000;
+    fetch.call(this)
+      .catch(err => {
+        // on error, report the error and back off
+        stream.pause();
+        stream.emit('error', err);
+        // TODO: clock.at
+        setTimeout(() => this.resume(), errBackoff);
+        errBackoff = errBackoff * 2;
+      })
+      .then(() => { errBackoff = 60000; })
+      .then(next);
+  });
+  stream.live = false;
+
+  return stream;
+}
+
+/**
+ * A writable stream that logs a metric stream to the console.
+ */
+export const metricLoggerStream = (prefix) => {
+  return new Writable({
+    objectMode: true,
+    write: (chunk, enc, next) => {
+      const delay = new Date() - chunk.ts;
+      console.log("%s: @%s: %s (%s; delayed %ss)",
+        prefix,
+        new Date(chunk.ts),
+        chunk.value,
+        chunk.live ? "live" : "historical",
+        chunk.live ? delay / 1000 : '-');
+      next();
+    },
+  });
+}
+
+/**
+ * Multiplex several metric streams into a single metric stream.  The
+ * resulting stream will have a datapoint for every unique timestamp
+ * in the input streams, but critically the values of those datapoints
+ * will be an array of the most recent input datapoint for each input
+ * stream at that time.
+ *
+ * The delay of the output stream will be greater than the maximum delay of any
+ * of the input streams.  This can cause data points to be missed when they
+ * arrive much later than expected.
+ *
+ * There is a "warm-up" period when the stream first starts, while it waits
+ * for historical data from all input streams.  During this time, all historical
+ * datapoints are buffered -- be careful of memory usage here!
+ *
+ * The `streams` option is the array of input streams:
+ * [
+ *   {stream: <readable stream>, name: stream name},
+ *   ...
+ * ]
+ *
+ * The remaining options are loader components.
+ */
+export const multiplexMetricStreams = ({streams, clock}) => {
+  const debug = debugModule('metricstream.multiplexMetricStreams');
+  let vtime = 0;
+  let warm = false;
+
+  const output = from(function (count, next) { });
+  output.live = false;
+
+  const inputs = streams.map(({stream, name}) => {
+    const input = {
+      stream,
+      name,
+      datapoints: [],
+      _delays: [],
+      delay: 1000, // starting guess
+      value: undefined,
+      live: false, // true if we have *read* a live datapoint
+    };
+
+    stream.on('live', () => {
+      if (!warm && _.all(inputs, s => s.stream.live)) {
+        debug('warmed - all input streams are now live');
+        warm = true;
+      }
+      update();
+    });
+
+    const wr = new Writable({
+      objectMode: true,
+      write: (chunk, enc, next) => {
+        if (chunk.ts < vtime) {
+          debug('discarding late datapoint %s at %s from stream %s',
+              chunk.value, chunk.ts, name);
+        }
+        input.datapoints.push(chunk);
+
+        // update delay for live datapoints using a simple moving average
+        if (chunk.live) {
+          input._delays.push(clock.msec() - chunk.ts);
+          input.delay = _.sum(input._delays) / input._delays.length;
+          while (input._delays.length > 3) {
+            input._delays.shift();
+          }
+        }
+
+        update();
+        next();
+      },
+    });
+    stream.pipe(wr);
+
+    return input;
+  });
+
+  // update the output stream based on input streams, until running
+  // out of data.  It's safe to call this whenever the input conditions
+  // change; it is properly debounced so that it will not actually run
+  // too often.
+  const update = clock.throttle(() => {
+    // no updates at all until everything is warm
+    if (!warm) {
+      return;
+    }
+
+    // update the output by advancing the virtual `vtime` to each successive
+    // timestamp appearing in any input stream, remaining at least `delay`
+    // seconds before the current wall time to allow lagging datapoints to
+    // come in.
+    while (true) {
+      const now = clock.msec();
+      
+      // applied delay is 10% more than the largest input delay, plus 500ms
+      const delay = _.max(inputs.map(i => i.delay)) * 1.1 + 500;
+      debug("applied delay is %ss", delay / 1000);
+
+      // calculate the next vtime, and bail out if we're not ready yet, planning
+      // to return when the time is right
+      const nextTs = _.min(inputs.map(i => i.datapoints[0] && i.datapoints[0].ts));
+      if (nextTs > now - delay) {
+        if (nextTs !== Infinity) {
+          setTimeout(update, nextTs - (now - delay));
+        }
+        break;
+      }
+
+      debug("advancing vtime from %s to %s", vtime, nextTs);
+      inputs.forEach(input => {
+        if (input.datapoints[0] && input.datapoints[0].ts <= nextTs) {
+          const dp = input.datapoints.shift();
+          input.latest = dp.value;
+          input.live = dp.live;
+        }
+      });
+
+      let live;
+      if (output.live) {
+        live = true;
+      } else {
+        live = _.all(inputs.map(i => i.live));
+        if (live) {
+          output.emit('live');
+          output.live = true;
+        }
+      }
+      output.emit('data', {ts: nextTs, value: inputs.map(i => i.latest), live});
+      vtime = nextTs;
+    }
+
+  }, 500, {leading: false, trailing: true});
+
+  return output;
+};

--- a/src/signalfx-rest.js
+++ b/src/signalfx-rest.js
@@ -1,0 +1,52 @@
+import request from 'superagent';
+
+/**
+ * A simple interface to the SignalFX REST API, since signalfx-nodejs does not
+ * supply one.
+ */
+
+export default class SignalFxRest {
+  constructor (api_token) {
+    this.api_token = api_token;
+  }
+
+  /**
+   * Call /timeserieswindow
+   *
+   * options:
+   * {
+   *   query,      // see https://developers.signalfx.com/docs/timeserieswindow
+   *   startMs,
+   *   endMs,
+   *   resolution,
+   * }
+   *
+   * Note that the resolution must be one of the whitelisted resolution values or
+   * you will get an error (or just no data).
+   */
+  async timeserieswindow ({query, startMs, endMs, resolution}) {
+    const qs = `query=${encodeURIComponent(query)}&startMs=${startMs}&endMs=${endMs}&resolution=${resolution}`;
+    const url = `https://api.signalfx.com/v1/timeserieswindow?${qs}`;
+
+    const res = await request
+      .get(url)
+      .type('application/json')
+      .set('X-SF-Token', this.api_token);
+
+    // data is helpfully keyed by a random string, or more than one if there were
+    // multiple matching time series.. but no information about which time series
+    // is which.
+    const data = res.body.data;
+    const keys = Object.keys(data);
+    if (keys.length > 1) {
+      throw new Error(`multiple time-series returned for query ${query}`);
+    } else if (keys.length == 0) {
+      // The quarter-baked SignalFx API helpfully returns "200 OK" for errors.
+      if (res.body.errors.length) {
+        throw new Error(res.body.errors[0].message);
+      }
+      return [];
+    }
+    return data[keys[0]];
+  }
+};

--- a/test/helper.js
+++ b/test/helper.js
@@ -59,6 +59,10 @@ class FakeClock {
     return this._msec;
   }
 
+  at (name, when, fn) {
+    this._timers.push({name, fn, next: when});
+  }
+
   periodically (interval, name, fn) {
     // note that, in testing, errors are fatal
     const run = async () => {

--- a/test/helper.js
+++ b/test/helper.js
@@ -71,6 +71,11 @@ class FakeClock {
     };
     this._timers.push({name, run, next: this._msec + interval});
   }
+
+  throttle (fn) {
+    // for testing, do not apply throttling
+    return fn;
+  }
 };
 
 export const makeCollector = async name => {

--- a/test/signalfx_test.js
+++ b/test/signalfx_test.js
@@ -1,0 +1,44 @@
+import assume from 'assume';
+import load from '../lib/main';
+import SignalFxRest from '../lib/signalfx-rest';
+
+suite('SignalFxRest', () => {
+  let rest;
+
+  before(async function () {
+    const cfg = await load('cfg', {profile: 'test'});
+    if (!cfg.signalfx.apiToken) {
+      this.skip();
+    }
+
+    rest = new SignalFxRest(cfg.signalfx.apiToken);
+  });
+
+  suite('timeserieswindow', async () => {
+    test('throws an error for a nonexistent metric', async () => {
+      let gotError;
+      await rest.timeserieswindow({
+        query: 'sf_metric:no.such.metric',
+        startMs: new Date() - 1000 * 3600 * 24,
+        endMs: new Date() - 1000 * 3600,
+        resolution: 1000 * 3600,
+      }).catch(err => gotError = err);
+      assume(gotError).inherits(Error);
+    });
+
+    test('returns a list of (timestamp, value) pairs for a demo metric', async () => {
+      let ts = await rest.timeserieswindow({
+        query: 'sf_metric:demo.trans.count AND demo_host:server6 ' +
+               'AND demo_customer:samslack.com AND demo_datacenter:Tokyo',
+        startMs: new Date() - 1000 * 3600 * 24,
+        endMs: new Date() - 1000 * 3600,
+        resolution: 1000 * 3600,
+      });
+      assume(ts).is.an('array');
+      assume(ts[0]).is.an('array');
+      assume(ts[0][0]).is.a('number');
+      assume(ts[0][1]).is.a('number');
+    });
+  });
+});
+

--- a/user-config-example.yml
+++ b/user-config-example.yml
@@ -1,4 +1,6 @@
 defaults:
+  signalfx:
+    apiToken: '...'
   pulse:
     username: '...'
     password: '...'


### PR DESCRIPTION
@jonasfj can I get a 30% review here?

The idea is that collectors will pull in a bunch of metrics, multiplex them together, then react to every change in any of the underlying metrics, and publish the result.  For the moment, this isn't publishing anything, of course.  The outputs will be tied to the declarations in a way that results in automatic documentation of all generated statistics.

I'll eventually have an SLO declared that looks at all three of the pending SLIs (decision, test, build) and outputs 1 if any of them are over their threshold.

Then I'll define an error budget which looks at the portion of time where that SLO has been 1.  That will take a little more equipment, but nothing this complex.

The interesting bit here, that I'd like some feedback on, is the metric streams.  I've tried to design them in such a way that, when we get signalflow access, I can replace the individual metric streams, or even the multiplexer, with a signalflow program.

I have a TODO in here about backfilling, but I don't plan to fix that too soon -- backfilled data isn't useful for generating downstream statistics, so I'm not sure there's much point adding it.