### PR TITLE
Service levels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 collect.conf.json
 .env
 user-config.yml
+yarn.lock

--- a/README.md
+++ b/README.md
@@ -21,6 +21,26 @@ Data are collected by "collectors"
   Tasks are measured constantly, even if they are still pending, making this a
   valid measure of the current pending time.
 
+## Service Levels
+
+This package calculates service levels.  The concepts for service levels are:
+
+ * SLI -- service level indicator.  This is a single measurement of some level of interest.  An example might be an API error rate, measured on five-minute intervals.
+ * SLO -- service level objective.  This is a boolean measurement of one or more SLIs: is each SLI within its parameters?  An example might be that the API error rate is less than 0.1%.
+ * EB -- error budget.  This is a measure of how frequently an SLO is true.  This introduces "nines".  An example might be that the error-rate SLO is OK 99.9% of the time over a 2-week span.  An error budget runs from 1.0 (SLO never false) to 0.0 (not meeting the "nines" requirement).
+
+The intended use of these calculations is to aim to spend error budgets, but
+not *overspend*.  An SLO that never fails means that the team can afford to
+move faster and break more stuff (or the SLO is a bad one) -- that budget is
+1.0 and should be spent!  But as the budget nears zero, the team should slow
+down and focus on reliability
+
+In fact, there is great value in not hitting SLOs at all times, as occasional
+failures force dependant services to handle failures correctly.
+
+See the Google "Site Reliability Engineering" book for additional information
+on service levels.
+
 # Running locally
 
 To run the server locally, compile (`npm run compile`) and then execute:

--- a/README.md
+++ b/README.md
@@ -2,22 +2,41 @@
 
 [![Build Status](https://travis-ci.org/taskcluster/taskcluster-stats-collector.svg?branch=master)](https://travis-ci.org/taskcluster/taskcluster-stats-collector)
 
-Reads TaskCluster messages off pulse and creates relevant statistics.
+Manages statistics collection for the TaskCluster team.
 
 # Data Collected
 
-## Running Tasks
+Data are collected by "collectors"
+
+## `running` -- Running Tasks
 
 * `tasks.<workerType>.resolved.<reasonResolved>` measures the time, in
   milliseconds, to resolve task with the given reason in the given workerType.
   Tasks are only measured when they are resolved, so this does not include
   times for running tasks.
 
-## Pending Tasks
+## `pending` -- Pending Tasks
 
 * `tasks.<workerType>.pending` measures the time that each task is pending.
   Tasks are measured constantly, even if they are still pending, making this a
   valid measure of the current pending time.
+
+# Running locally
+
+To run the server locally, compile (`npm run compile`) and then execute:
+
+```
+NODE_ENV=development DEBUG=* node lib/main server
+```
+
+Note that you can use `--collectors` to specify the collectors you would like
+to run in development mode, thereby avoiding noise from collectors you're not
+working on:
+
+```
+NODE_ENV=development DEBUG=* node lib/main server --collectors pending sli.gecko.pending.test
+```
+
 
 # Testing
 

--- a/config.yml
+++ b/config.yml
@@ -1,4 +1,6 @@
 defaults:
+  signalfx:
+    apiToken: !env SIGNALFX_API_TOKEN
   pulse:
     username: !env PULSE_USERNAME
     password: !env PULSE_PASSWORD

--- a/package.json
+++ b/package.json
@@ -16,10 +16,11 @@
     "lodash": "^3.6.0",
     "mocha": "^2.4.5",
     "mocha-eslint": "^2.0.1",
+    "signalfx": "^4.0.0",
     "slugid": "1.0.3",
-    "taskcluster-lib-loader": "1.1.0",
     "taskcluster-client": "^0.23.16",
     "taskcluster-lib-docs": "^3.0.2",
+    "taskcluster-lib-loader": "1.1.0",
     "taskcluster-lib-monitor": "^0.2.1",
     "tc-rules": "^3.0.1",
     "typed-env-config": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -8,6 +8,9 @@
     "pretest": "npm run compile",
     "install": "npm run compile"
   },
+  "devDependencies": {
+    "assume": "^1.4.1"
+  },
   "dependencies": {
     "babel-compile": "^2.0.0",
     "babel-preset-taskcluster": "^3.0.0",
@@ -16,6 +19,7 @@
     "lodash": "^3.6.0",
     "mocha": "^2.4.5",
     "mocha-eslint": "^2.0.1",
+    "requestretry": "^1.12.0",
     "signalfx": "^4.0.0",
     "slugid": "1.0.3",
     "taskcluster-client": "^0.23.16",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "mocha": "^2.4.5",
     "mocha-eslint": "^2.0.1",
     "requestretry": "^1.12.0",
+    "sculpt": "^0.1.7",
     "signalfx": "^4.0.0",
     "slugid": "1.0.3",
     "taskcluster-client": "^0.23.16",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "taskcluster-lib-loader": "1.1.0",
     "taskcluster-lib-monitor": "^0.2.1",
     "tc-rules": "^3.0.1",
-    "typed-env-config": "^1.0.0"
+    "typed-env-config": "^1.0.0",
+    "yargs": "^6.4.0"
   },
   "engines": {
     "node": "^5.10.1",

--- a/src/clock.js
+++ b/src/clock.js
@@ -1,31 +1,59 @@
 import debugModule from 'debug';
+import _ from 'lodash';
 
 const debug = debugModule('clock');
 
 class Clock {
   constructor ({monitor}) {
     this.monitor = monitor;
+    this._stop = false;
   }
 
-  // Return the current time in milliseconds
+  /**
+   * Return the current time in milliseconds
+   */
   msec () {
     return new Date().getTime();
   }
 
-  // Run fn periodically, whether async or not, surviving errors
+  async _runFunction (name, fn) {
+    debug(`Running '${name}'`);
+    try {
+      await fn();
+    } catch (err) {
+      this.monitor.reportError(err);
+      debug(`'${name}' failed: ${err}`);
+    }
+  }
+
+  /**
+   * Like the global `setTimeout`, but with logging and handling for async
+   * errors.  Note that this does not return a timeout ID and cannot be
+   * cancelled (but that functionality can be added if needed!)
+   */
+  setTimeout (name, fn, delay) {
+    setTimeout(() => this._runFunction(name, fn), delay);
+  }
+
+  /**
+   * Run fn periodically, whether async or not, surviving errors
+   */
   periodically (interval, name, fn) {
     setTimeout(async () => {
-      while (true) {
-        debug('Running ' + name);
-        try {
-          await fn();
-        } catch (err) {
-          this.monitor.reportError(err);
-          console.log('%s failed: %s', name, err);
-        }
+      while (!this._stop) {
+        await this._runFunction(name, fn);
         await new Promise(resolve => setTimeout(resolve, interval));
       }
     }, interval);
+  }
+
+  /**
+   * Exactly like lodash's throttle.
+   *
+   * (this exists just to avoid throttling in tests)
+   */
+  throttle () {
+    return _.throttle.apply(_, arguments);
   }
 };
 

--- a/src/collector/gecko-pending.js
+++ b/src/collector/gecko-pending.js
@@ -1,0 +1,119 @@
+import {max} from 'lodash';
+import sli from '../sli';
+import slo from '../slo';
+import eb from '../eb';
+
+const MINUTE = 60 * 1000;
+
+sli.declare({
+  name: 'gecko.pending.test',
+  description: [
+    'The maximum pending time of any of the gecko test workerTypes.',
+    '',
+    'Each workerType is measured at the 95th percentile over a 5-minute',
+    'period to avoid outliers.',
+  ].join('\n'),
+  // TODO: determine these dynamically from the AWS provisioner
+  inputs: [
+    'desktop-test',
+    'desktop-test-large',
+    'desktop-test-xlarge',
+    'gecko-t-linux-medium',
+    'gecko-t-linux-large',
+    'gecko-t-linux-xlarge',
+    'gecko-t-win10-64',
+    'gecko-t-win10-64-gpu',
+    'gecko-t-win7-32',
+    'gecko-t-win7-32-gpu',
+  ].map(wt => {
+    return {
+      spec: 'statsum',
+      metric: `tc-stats-collector.tasks.aws-provisioner-v1.${wt}.pending`,
+      resolution: '5m',
+      percentile: 95,
+    };
+  }),
+  aggregate: max,
+});
+
+sli.declare({
+  name: 'gecko.pending.build',
+  description: [
+    'The maximum pending time of any of the gecko build workerTypes.',
+    '',
+    'Each workerType is measured at the 95th percentile over a 5-minute',
+    'period to avoid outliers.',
+  ].join('\n'),
+  // TODO: determine these dynamically from the AWS provisioner
+  inputs: [
+    'gecko-1-b-android',
+    'gecko-1-b-linux',
+    'gecko-1-b-macosx64',
+    'gecko-1-b-win2012',
+    'gecko-1-b-win2012-beta',
+    'gecko-2-b-android',
+    'gecko-2-b-linux',
+    'gecko-2-b-macosx64',
+    'gecko-2-b-win2012',
+    'gecko-3-b-android',
+    'gecko-3-b-linux',
+    'gecko-3-b-macosx64',
+    'gecko-3-b-win2012',
+  ].map(wt => {
+    return {
+      spec: 'statsum',
+      metric: `tc-stats-collector.tasks.aws-provisioner-v1.${wt}.pending`,
+      resolution: '5m',
+      percentile: 95,
+    };
+  }),
+  aggregate: max,
+});
+
+sli.declare({
+  name: 'gecko.pending.other',
+  description: [
+    'The maximum pending time of any of the non-test, non-build gecko workerTypes.',
+    'This includes the decision task and image building.',
+    '',
+    'Each workerType is measured at the 95th percentile over a 5-minute',
+    'period to avoid outliers.',
+  ].join('\n'),
+  // TODO: determine these dynamically from the AWS provisioner
+  inputs: [
+    'gecko-decision',
+    'taskcluster-images',
+  ].map(wt => {
+    return {
+      spec: 'statsum',
+      metric: `tc-stats-collector.tasks.aws-provisioner-v1.${wt}.pending`,
+      resolution: '5m',
+      percentile: 95,
+    };
+  }),
+  aggregate: max,
+});
+
+slo.declare({
+  name: 'gecko.pending',
+  description: [
+    'The pending time for gecko jobs should be within a reasonable limit.',
+    'specifically, test and build jobs should start within 30 minutes of',
+    'being scheduled, while other jobs should start within 20 minutes.',
+  ].join('\n'),
+  indicators: [
+    {sli: 'gecko.pending.other', resolution: '5m', met: v => v < 20 * MINUTE},
+    {sli: 'gecko.pending.test', resolution: '5m', met: v => v < 30 * MINUTE},
+    {sli: 'gecko.pending.build', resolution: '5m', met: v => v < 30 * MINUTE},
+  ],
+});
+
+eb.declare({
+  name: 'gecko.pending',
+  description: [
+    'Gecko pending times should be within their thresholds 99.5% of the time,',
+    'measured over the previous two weeks.',
+  ].join('\n'),
+  nines: 99.5,
+  days: 14,
+});

--- a/src/collector/running.js
+++ b/src/collector/running.js
@@ -5,8 +5,8 @@ collectorManager.collector({
   name: 'running',
   requires: ['monitor', 'listener'],
   // support emitting via statsum or directly as a time series
-}, ({monitor, listener, debug}) => {
-  listener.on('task-message', ({action, payload}) => {
+}, function () {
+  this.listener.on('task-message', ({action, payload}) => {
     try {
       if (action === 'task-pending' || action === 'task-running') {
         return;
@@ -24,12 +24,12 @@ collectorManager.collector({
         if (run.reasonResolved !== 'deadline-exceeded') {
           var started = new Date(run.started);
           var resolved = new Date(run.resolved);
-          monitor.measure(`tasks.${workerType}.running`, resolved - started);
+          this.monitor.measure(`tasks.${workerType}.running`, resolved - started);
         }
-        monitor.count(`tasks.${workerType}.resolved.${run.reasonResolved}`);
+        this.monitor.count(`tasks.${workerType}.resolved.${run.reasonResolved}`);
       });
     } catch (err) {
-      debug('Failed to process message %s with error: %s, as JSON: %j',
+      this.debug('Failed to process message %s with error: %s, as JSON: %j',
             action, err, err, err.stack);
     }
   });

--- a/src/collectormanager.js
+++ b/src/collectormanager.js
@@ -1,6 +1,7 @@
 import path from 'path';
 import fs from 'fs';
 import debug from 'debug';
+import {find} from 'lodash';
 var EventEmitter = require('events');
 
 /**
@@ -66,6 +67,9 @@ class CollectorManager extends EventEmitter {
   collector (options, setup) {
     if (!options.name) {
       throw new Error('Collector must have a name');
+    }
+    if (find(this.collectors, {name: options.name})) {
+      throw new Error('Collector must have a unique name');
     }
     options._fullname = `collector.${options.name}`;
     options._setup = setup;

--- a/src/eb.js
+++ b/src/eb.js
@@ -1,0 +1,89 @@
+import collectorManager from './collectormanager';
+import {sum} from 'lodash';
+
+const MINUTE = 1000 * 60;
+const HOUR = MINUTE * 60;
+const DAY = 24 * HOUR;
+
+/**
+ * Declare an error budget.  This will declare and implement a collector based on the
+ * given options.  An error budget analyzes an SLO over a given time period, and scales
+ * from zero (SLO was missed more than allowed during that time period) to one (SLO was
+ * met for the entire time period).
+ *
+ * options: {
+ *  name: '..',         // name of the error budget (and underlying objective)
+ *  description: '..',  // description of the error budget
+ *  requires: [..],     // any additional loader components required
+ *  nines: 99.9,        // the percent of time the objective should be met
+ *  days: 14,           // the days over which to measure the percent
+ * }
+ */
+exports.declare = ({name, description, requires, nines, days}) => {
+  // Time to delay after the top of an hour, to ensure that all datapoints are in.
+  // SLIs can be delayed by 5 minutes, and SLOs by an additional 5, so wait 15.
+  const DELAY = 15 * MINUTE;
+
+  collectorManager.collector({
+    name: `eb.${name}`,
+    description,
+    requires: ['monitor', 'clock', 'signalFxRest', 'ingest'].concat(requires || []),
+  }, function () {
+    const history = [];
+
+    this.scheduleNextRun = () => {
+      const now = this.clock.msec();
+      // DELAY after the next even hour
+      const nextRun = now - now % HOUR + HOUR + DELAY;
+
+      const run = () => {
+        this.scheduleNextRun();
+        return this.calculate();
+      };
+      this.debug(`next calculation at ${new Date(nextRun)}`);
+      this.clock.setTimeout(`calculate error budget for ${name}`, run, nextRun - now);
+    };
+
+    this.calculate = async () => {
+      let now = this.clock.msec();
+      now -= now % HOUR; // round down to the previous hour
+
+      let earliest = now - days * DAY;
+
+      // fetch new data and add to history
+      let startMs = earliest;
+      let endMs = this.clock.msec();
+      if (history.length) {
+        startMs = history[history.length - 1][0] + HOUR;
+      }
+
+      (await this.signalFxRest.timeserieswindow({
+        query: `sf_metric:slo.${name}`,
+        startMs, endMs,
+        resolution: HOUR,
+      })).forEach(dp => history.push(dp));
+
+      // remove old history
+      while (history[0] && history[0][0] < earliest) {
+        history.unshift();
+      }
+
+      // calculate the budget: 1.0 = never failed, 0.0 = failed more than the specified nines
+      const hoursExceeded = sum(history.map(h => h[1]));
+      const fractionExceeded = hoursExceeded / (days * 24);
+      const maxFraction = (100 - nines) / 100;
+      const budget = fractionExceeded > maxFraction ? 0 : 1 - fractionExceeded / maxFraction;
+
+      this.debug(`Error budget for ${name} at ${new Date(now)} calculated at ${budget}`);
+      this.ingest.send({
+        gauges: [{
+          metric: `eb.${name}`,
+          value: budget,
+          timestamp: now,
+        }],
+      });
+    };
+
+    this.scheduleNextRun();
+  });
+};

--- a/src/main.js
+++ b/src/main.js
@@ -8,8 +8,15 @@ let taskcluster = require('taskcluster-client');
 let signalfx = require('signalfx');
 import Clock from './clock';
 import SignalFxRest from './signalfx-rest';
+import yargs from 'yargs';
 
-collectorManager.setup();
+const argv = yargs
+  .usage('Usage: $0 --collectors C')
+  .describe('collectors', 'Collectors to run (default all)')
+  .array('collectors')
+  .argv;
+
+collectorManager.setup(argv);
 
 let load = loader(Object.assign({
   cfg: {
@@ -88,6 +95,7 @@ let load = loader(Object.assign({
 // If this file is executed launch component from first argument
 if (!module.parent) {
   load(process.argv[2], {
+    argv,
     profile: process.env.NODE_ENV,
   }).catch(err => {
     console.log(err.stack);

--- a/src/main.js
+++ b/src/main.js
@@ -7,6 +7,7 @@ let collectorManager = require('./collectormanager');
 let taskcluster = require('taskcluster-client');
 let signalfx = require('signalfx');
 import Clock from './clock';
+import SignalFxRest from './signalfx-rest';
 
 collectorManager.setup();
 
@@ -45,7 +46,12 @@ let load = loader(Object.assign({
 
   ingest: {
     requires: ['cfg'],
-    setup: async ({cfg}) => new signalfx.Ingest(cfg.signalfx.apiToken),
+    setup: ({cfg}) => new signalfx.Ingest(cfg.signalfx.apiToken),
+  },
+
+  signalFxRest: {
+    requires: ['cfg'],
+    setup: ({cfg}) => new SignalFxRest(cfg.signalfx.apiToken),
   },
 
   docs: {

--- a/src/main.js
+++ b/src/main.js
@@ -5,6 +5,7 @@ let docs = require('taskcluster-lib-docs');
 let config = require('typed-env-config');
 let collectorManager = require('./collectormanager');
 let taskcluster = require('taskcluster-client');
+let signalfx = require('signalfx');
 import Clock from './clock';
 
 collectorManager.setup();
@@ -40,6 +41,11 @@ let load = loader(Object.assign({
   queue: {
     requires: [],
     setup: () => new taskcluster.Queue(),
+  },
+
+  ingest: {
+    requires: ['cfg'],
+    setup: async ({cfg}) => new signalfx.Ingest(cfg.signalfx.apiToken),
   },
 
   docs: {

--- a/src/metricstream.js
+++ b/src/metricstream.js
@@ -1,0 +1,311 @@
+import {Writable} from 'stream';
+import sculpt from 'sculpt';
+import {Readable} from 'stream';
+import _ from 'lodash';
+import debugModule from 'debug';
+import RESOLUTIONS from './resolutions';
+
+const HOUR = 1000 * 60 * 60;
+
+/**
+ *
+ * A metric stream is an object stream that produces data points from the given
+ * metric, starting at the given time and continuing on until it runs "live".
+ *
+ * The stream objects are datapoints:
+ * {
+ *   ts,      // milliseconds
+ *   value,   // value of the datapoint at ts
+ *   live,    // true if this is a "live" datapoint (not historical)
+ * }
+ *
+ * Note that "live" datapoints may still have a delay of a few seconds (that is,
+ * `ts` may be a few seconds in the past) due to message propagation delays, polling,
+ * etc.
+ *
+ * Metric streams emit a "live" event and set their `live` property true
+ * after the last historical datapoint has been pushed into the stream.  Note
+ * that events and stream data are not synchronized, so this event may arrive
+ * before all buffered historical data is consumed.
+ *
+ * NOTE: the "through" streams here will not pass along the live event and property.
+ */
+
+/**
+ * Return a metric stream for the metric identified by the given query, starting
+ * at `start` and with the given resolution.  The `clock` and `signalFxRest` options
+ * should come from the loader components of the same name.
+ *
+ * Resolution must be one of `5s`, `1m`, `5m`, '1h'.
+ */
+export const signalFxMetricStream = ({query, resolution, start, clock, signalFxRest}) => {
+  let latestDatapoint = start - 1;  // -1 to capture a datapoint at start
+  let liveData = false;
+
+  // NOTE: SignalFx's quantizer delays incoming data by its resolution; that
+  // is, at 5m resolution you won't see a datapoint until the next multiple of
+  // 5 minutes -- acutally a bit later.  Resolutions are calculated based on
+  // the incoming data, not on the requested resolution.
+  const QUANTIZER_DELAY = 15000;
+
+  const resolutionMs = RESOLUTIONS[resolution];
+  if (!resolutionMs) {
+    throw new Error(`invalid resolution ${resolution}`);
+  }
+
+  let output;
+  const fetch = () => {
+    (async function () {
+      const now = clock.msec();
+
+      let startMs = latestDatapoint;
+      let endMs = now;
+
+      (await signalFxRest.timeserieswindow({
+        query: query,
+        startMs, endMs,
+        resolution: resolutionMs,
+      })).forEach(dp => {
+        // skip if we've seen this datapoint before
+        if (dp[0] <= latestDatapoint) {
+          return;
+        }
+        latestDatapoint = dp[0];
+        output.emit('data', {ts: dp[0], value: dp[1], live: liveData});
+      });
+
+      // if we are up to the current time, then remaining samples will be "live"
+      if (endMs === now) {
+        if (!liveData) {
+          output.live = true;
+          output.emit('live');
+        }
+        liveData = true;
+      }
+
+      // If we're live and there's no more data, assume the next datapoint will
+      // be here at the next even interval of the resolution, or shortly thereafter.
+      if (liveData) {
+        let wakeup = now + resolutionMs;  // go to the next resolution bin
+        wakeup -= wakeup % resolutionMs;  // round down to the beginning of the bin
+        wakeup += QUANTIZER_DELAY;        // and wait for the quantizer to write out the data
+
+        clock.setTimeout(`fetch next datapoint for ${query}`,
+            fetch, wakeup > now ? wakeup - now : 0);
+      } else {
+        // still historical, so query right away
+        process.nextTick(fetch);
+      }
+    })().catch(err => {
+      output.emit('error', err);
+      clock.setTimeout(`retry fetch ${query} after error`, fetch, 10000);
+    });
+  };
+
+  let started = false;
+
+  output = new Readable({read: () => {
+    // start pushing
+    if (!started) {
+      started = true;
+      fetch();
+    }
+    // always pause, as this is a push (non-flowing) stream
+    output.pause();
+  }});
+  output.live = false;
+
+  return output;
+};
+
+/**
+ * A through stream that logs a metric stream to the console; options:
+ *
+ *  {
+ *    prefix: logging prefix,
+ *    log: logging function (default console.log),
+ *    clock: clock object for calculating delay (optional)
+ *  }
+ */
+export const metricLoggerStream = ({prefix, log, clock}) => {
+  const _prefix = prefix ? `${prefix}: ` : '';
+  const _log = log || console.log;
+  const msec = () => clock && clock.msec() || +new Date();
+
+  return sculpt.tap((chunk) =>
+    _log(`${_prefix}ts=${chunk.ts}: ${chunk.value} ` +
+         (chunk.live ? `(live, ${(msec() - chunk.ts) / 1000}s delay)` : '(historical)'))
+  );
+};
+
+/**
+ * A writeable stream that logs a metric stream directly to SignalFx.
+ *
+ * options: {
+ *   metric: // metric name
+ *   type: // metric type ('gauge', 'cumulative_counter', or 'counter')
+ *   ingest: // Ingest object from the SignalFx client
+ * }
+ */
+export const signalFxIngester = ({metric, type, ingest}) => {
+  const plurals = {
+    gauge: 'gauges',
+    cumulative_counter: 'cumulative_counters',
+    counter: 'counters',
+  };
+  if (!plurals[type]) {
+    throw new Error(`Unknown metric type ${type}`);
+  }
+
+  return sculpt.tap((chunk) => {
+    const req = {};
+    req[plurals[type]] = [{
+      metric,
+      value: Math.round(chunk.value),
+      timestamp: chunk.ts,
+    }];
+    ingest.send(req);
+  });
+};
+
+/**
+ * Multiplex several metric streams into a single metric stream.  The
+ * resulting stream will have a datapoint for every unique timestamp
+ * in the input streams, but critically the values of those datapoints
+ * will be an array of the most recent input datapoint for each input
+ * stream at that time.
+ *
+ * The delay of the output stream will be greater than the maximum delay of any
+ * of the input streams.  This can cause data points to be missed when they
+ * arrive much later than expected.
+ *
+ * There is a "warm-up" period when the stream first starts, while it waits
+ * for historical data from all input streams.  During this time, all historical
+ * datapoints are buffered -- be careful of memory usage here!
+ *
+ * options: {
+ *    name: name of the multiplexed stream,
+ *    streams: input streams,
+ *    clock: the clock component
+ *  }
+ *
+ * The `streams` option is the array of input streams:
+ * [
+ *   {stream: <readable stream>, name: stream name},
+ *   ...
+ * ]
+ */
+export const multiplexMetricStreams = ({name, streams, clock}) => {
+  const debug = debugModule(`multiplexMetricStreams.${name || 'unnamed'}`);
+  let vtime = 0;
+  let warm = false;
+
+  // output is a readable stream, but with no read method (so, only operating in pull mode)
+  const output = new Readable({objectMode: true, read: function () { this.pause(); }});
+  output.live = false;
+
+  const inputs = streams.map(({stream, name}) => {
+    const input = {
+      stream,
+      name,
+      datapoints: [],
+      _delays: [],
+      delay: 1000, // starting guess
+      value: undefined,
+      // true if we have *udpated to* a live datapoint, which may occur after
+      // we get the 'live' event from this input
+      live: false,
+    };
+
+    stream.on('live', () => {
+      if (!warm && _.all(inputs, s => s.stream.live)) {
+        debug('warmed up: all input streams are now live');
+        warm = true;
+      }
+      update();
+    });
+
+    stream.on('data', (chunk) => {
+      if (chunk.ts < vtime) {
+        debug('discarding late datapoint %s at %s from stream %s',
+            chunk.value, chunk.ts, name);
+      }
+      input.datapoints.push(chunk);
+
+      // update delay for live datapoints using a simple moving average
+      if (chunk.live) {
+        input._delays.push(clock.msec() - chunk.ts);
+        input.delay = _.sum(input._delays) / input._delays.length;
+        while (input._delays.length > 3) {
+          input._delays.shift();
+        }
+      }
+
+      update();
+    });
+
+    return input;
+  });
+
+  // update the output stream based on input streams, until running
+  // out of data.  It's safe to call this whenever the input conditions
+  // change, as it is properly debounced so that it will not actually run
+  // too often.
+  const update = clock.throttle(() => {
+    // no updates at all until everything is warm
+    if (!warm) {
+      return;
+    }
+
+    // update the output by advancing the virtual `vtime` to each successive
+    // timestamp appearing in any input stream, remaining at least `delay`
+    // seconds before the current wall time to allow lagging datapoints to
+    // come in.
+    while (true) {
+      const now = clock.msec();
+
+      // applied delay is 12.5% more than the largest input delay, plus 500ms
+      const inputDelay = _.max(inputs.map(i => i.delay));
+      const delay = inputDelay + (inputDelay >> 3) + 500;
+
+      // calculate the next vtime, and bail out if we're not ready yet, planning
+      // to return when the time is right
+      const nextTs = _.min(inputs.map(i => i.datapoints[0] && i.datapoints[0].ts));
+      if (nextTs > now - delay) {
+        if (nextTs !== Infinity) {
+          clock.setTimeout(`update ${name || 'unnamed mux'}`, update, nextTs - (now - delay));
+        }
+
+        // we're now live, even if some inputs have yet to produce any live
+        // datapoints
+        if (!output.live) {
+          output.emit('live');
+          output.live = true;
+        }
+        break;
+      }
+
+      inputs.forEach(input => {
+        if (input.datapoints[0] && input.datapoints[0].ts <= nextTs) {
+          const dp = input.datapoints.shift();
+          input.latest = dp.value;
+          input.live = dp.live;
+        }
+      });
+
+      let live = output.live;
+      if (!live) {
+        live = _.all(inputs.map(i => i.live));
+        if (live) {
+          output.live = true;
+          output.emit('live');
+        }
+      }
+      output.emit('data', {ts: nextTs, value: inputs.map(i => i.latest), live});
+      vtime = nextTs;
+    }
+
+  }, 500, {leading: false, trailing: true});
+
+  return output;
+};

--- a/src/resolutions.js
+++ b/src/resolutions.js
@@ -1,0 +1,8 @@
+const RESOLUTIONS = {
+  '5s': 5 * 1000,
+  '1m': 60 * 1000,
+  '5m': 5 * 60 * 1000,
+  '1h': 60 * 60 * 1000,
+};
+
+export default RESOLUTIONS;

--- a/src/signalfx-rest.js
+++ b/src/signalfx-rest.js
@@ -1,0 +1,63 @@
+import request from 'requestretry';
+
+/**
+ * A simple interface to the SignalFX REST API, since signalfx-nodejs does not
+ * supply one.
+ */
+
+export default class SignalFxRest {
+  constructor (api_token) {
+    this.api_token = api_token;
+  }
+
+  /**
+   * Call /timeserieswindow
+   *
+   * options:
+   * {
+   *   query,      // see https://developers.signalfx.com/docs/timeserieswindow
+   *   startMs,
+   *   endMs,
+   *   resolution,
+   * }
+   *
+   * Note that the resolution must be one of the whitelisted resolution values or
+   * you will get an error (or just no data).
+   */
+  async timeserieswindow ({query, startMs, endMs, resolution}) {
+    const qs = `query=${encodeURIComponent(query)}&startMs=${startMs}&endMs=${endMs}&resolution=${resolution}`;
+    const url = `https://api.signalfx.com/v1/timeserieswindow?${qs}`;
+
+    const res = await request.get({
+      url,
+      json: true,
+      headers: {
+        'Content-Type': 'application/json',
+        'X-SF-Token': this.api_token,
+      },
+      maxAttempts: 5,
+      retryDelay: 2000,
+      retryStrategy: request.RetryStrategies.HTTPOrNetworkError,
+    });
+
+    if (res.statusCode != 200) {
+      throw new Error(`Error from signalfx: ${JSON.stringify(res.body)}`);
+    }
+
+    // data is helpfully keyed by a random string, or more than one if there were
+    // multiple matching time series.. but no information about which time series
+    // is which.
+    const data = res.body.data;
+    const keys = Object.keys(data);
+    if (keys.length > 1) {
+      throw new Error(`multiple time-series returned for query ${query}`);
+    } else if (keys.length == 0) {
+      // The quarter-baked SignalFx API helpfully returns "200 OK" for errors.
+      if (res.body.errors.length) {
+        throw new Error(res.body.errors[0].message);
+      }
+      return [];
+    }
+    return data[keys[0]];
+  }
+};

--- a/src/sli.js
+++ b/src/sli.js
@@ -1,0 +1,140 @@
+import RESOLUTIONS from './resolutions';
+import collectorManager from './collectormanager';
+import sculpt from 'sculpt';
+import {
+  signalFxIngester,
+  signalFxMetricStream,
+  multiplexMetricStreams,
+  metricLoggerStream,
+} from './metricstream';
+
+/**
+ * Declare an SLI, a service level indicator.  This will declare and implement
+ * a collector based on the options.
+ *
+ * options: {
+ *  name: '..',         // SLI name (collector name will include an 'sli' prefix)
+ *  description: '..',  // description of the SLI, for documentation
+ *  requires: [..],     // any additional loader components required
+ *  inputs: [..]        // input metric stream specs
+ *    OR:
+ *  inputs: async function() { ..; return [..]; }`
+ *  aggregate: ([v0, v1, ..]) => v,  // function to aggregate inputs into output
+ * }
+ *
+ * Stream specs can have any of the following forms:
+ *
+ * // metrics input directly into signalFx:
+ * {spec: 'signalfx', metric: 'bugzilla.intermittents', resolution: '1h'}
+ *
+ * // metrics submitted via statsum
+ * {spec: 'statsum', metric: 'taskcluster-auth.api.azureTableSAS.all',
+ *  percentile: 95, resolution: '1h'}
+ */
+
+exports.declare = ({name, description, requires, inputs, aggregate}) => {
+  collectorManager.collector({
+    name: `sli.${name}`,
+    description,
+    requires: ['monitor', 'clock', 'signalFxRest', 'ingest'].concat(requires || []),
+  }, async function () {
+    let inputSpecs;
+    if (typeof inputs === 'function') {
+      inputSpecs = await inputs.call(this);
+    } else {
+      inputSpecs = inputs;
+    }
+
+    const inputSources = inputSpecs.map(spec => sourceFromSpec(spec, this));
+
+    // multiplex those streams together
+    const muxStream = multiplexMetricStreams({
+      name: `sli.${name}.mux`,
+      streams: inputSources,
+      clock: this.clock,
+    });
+
+    // transform it with the aggregate function
+    const aggregateStream = sculpt.filter(dp => {
+      dp.value = aggregate.call(this, dp.value);
+      return dp;
+    });
+
+    // ingest the result
+    const ingestStream = signalFxIngester({
+      metric: `sli.${name}`,
+      type: 'gauge',
+      ingest: this.ingest,
+    });
+
+    // and log it
+    const logStream = metricLoggerStream({
+      prefix: 'write datapoint',
+      log: msg => this.debug(msg),
+      clock: this.clock,
+    });
+
+    // add logs to each input, too
+    inputSources.forEach(src => {
+      src.stream.pipe(metricLoggerStream({
+        prefix: `received from ${src.name}`,
+        log: msg => this.debug(msg),
+        clock: this.clock,
+      }));
+    });
+
+    // handle errors from any of those streams..
+    const handleStreamError = ({stream, name}) => {
+      stream.on('error', err => {
+        this.monitor.reportError(err);
+        this.debug(`error from stream ${name}: ${err}`);
+      });
+    };
+    inputSources.forEach(handleStreamError);
+    handleStreamError({stream: muxStream, name: 'muxStream'});
+    handleStreamError({stream: aggregateStream, name: 'aggregateStream'});
+    handleStreamError({stream: ingestStream, name: 'ingestStream'});
+    handleStreamError({stream: logStream, name: 'logStream'});
+
+    // and pipe them together
+    muxStream.pipe(aggregateStream).pipe(ingestStream).pipe(logStream);
+  });
+};
+
+/**
+ * Given a "stream spec", return a name and metric stream.
+ *
+ * The return value is in the format {name, stream}.
+ */
+const sourceFromSpec = (spec, components) => {
+  const specType = spec.spec;
+  if (specType === 'signalfx') {
+    const {metric, resolution} = spec;
+    const resolutionMs = RESOLUTIONS[resolution];
+
+    if (!metric || !resolution || !resolutionMs) {
+      throw new Error(`invalid stream spec ${spec}`);
+    }
+
+    return {
+      name: metric,
+      stream: signalFxMetricStream({
+        query: `sf_metric:${metric}`,
+        resolution: resolution,
+        // go back far enough to get some history..
+        start: components.clock.msec() - 2 * resolutionMs,
+        clock: components.clock,
+        signalFxRest: components.signalFxRest,
+      }),
+    };
+  } else if (specType === 'statsum') {
+    const {metric, resolution, percentile} = spec;
+    return sourceFromSpec({
+      spec: 'signalfx',
+      metric: `${metric}.${resolution}.p${percentile}`,
+      resolution,
+    }, components);
+  } else {
+    throw new Error(`unknown stream spec type ${specType}`);
+  }
+};

--- a/src/slo.js
+++ b/src/slo.js
@@ -1,0 +1,112 @@
+import RESOLUTIONS from './resolutions';
+import collectorManager from './collectormanager';
+import sculpt from 'sculpt';
+import _ from 'lodash';
+import {
+  signalFxMetricStream,
+  signalFxIngester,
+  multiplexMetricStreams,
+  metricLoggerStream,
+} from './metricstream';
+
+/**
+ * Declare an SLO, a service level objective.  This will declare and implement
+ * a collector based on the options.
+ *
+ * A service level objective defines thresholds for a collection of SLIs.  If
+ * any of the thresholds are exceeded, the objective is not met and emits 0 (false).
+ * Otherwise, it emits 1.
+ *
+ * options: {
+ *  name: '..',  // SLO name (collector name will add an 'slo' prefix)
+ *  description: '..',  // description of the SLO, for documentation
+ *  requires: [..], // any additional loader components required
+ *  indicators: [{
+ *    sli: '..',        // SLI name
+ *    resolution: '..', // resolution of the SLI (its shortest underlying resolution)
+ *    met: v => ..,     // function to determine if the objective is met for this SLI,
+ *                      // given the value of the SLI
+ *  }, {
+ *    ...
+ *  }]
+ * }
+ */
+
+exports.declare = ({name, description, requires, indicators}) => {
+  collectorManager.collector({
+    name: `slo.${name}`,
+    description,
+    requires: ['monitor', 'clock', 'signalFxRest', 'ingest'].concat(requires || []),
+  }, async function () {
+    const inputSources = indicators.map(({sli, resolution}) => {
+      const resolutionMs = RESOLUTIONS[resolution];
+      const stream = signalFxMetricStream({
+        query: `sf_metric:sli.${sli}`,
+        resolution: resolution,
+        // go back two resolutions, hoping to span any outages
+        start: this.clock.msec() - 2 * resolutionMs,
+        clock: this.clock,
+        signalFxRest: this.signalFxRest,
+      });
+      return {name: sli, stream};
+    });
+
+    // multiplex those streams together
+    const muxStream = multiplexMetricStreams({
+      name: `slo.${name}.mux`,
+      streams: inputSources,
+      clock: this.clock,
+    });
+
+    // transform it with the aggregate function
+    const aggregateStream = sculpt.filter(dp => {
+      if (_.all(dp.value.map((value, i) => indicators[i].met(value)))) {
+        // all objectives met -> SLO = 1
+        dp.value = 1;
+      } else {
+        dp.value = 0;
+      }
+      return dp;
+    });
+
+    // ingest the result
+    const ingestStream = signalFxIngester({
+      metric: `slo.${name}`,
+      type: 'gauge',
+      ingest: this.ingest,
+    });
+
+    // and log it
+    const logStream = metricLoggerStream({
+      prefix: 'write datapoint',
+      log: msg => this.debug(msg),
+      clock: this.clock,
+    });
+
+    // add logs to each input, too
+    inputSources.forEach(src => {
+      src.stream.pipe(metricLoggerStream({
+        prefix: `received from ${src.name}`,
+        log: msg => this.debug(msg),
+        clock: this.clock,
+      }));
+    });
+
+    // handle errors from any of those streams..
+    const handleStreamError = ({stream, name}) => {
+      stream.on('error', err => {
+        this.monitor.reportError(err);
+        this.debug(`error from stream ${name}: ${err}`);
+      });
+    };
+    inputSources.forEach(handleStreamError);
+    handleStreamError({stream: muxStream, name: 'muxStream'});
+    handleStreamError({stream: aggregateStream, name: 'aggregateStream'});
+    handleStreamError({stream: ingestStream, name: 'ingestStream'});
+    handleStreamError({stream: logStream, name: 'logStream'});
+
+    // and pipe them together
+    muxStream.pipe(aggregateStream).pipe(ingestStream).pipe(logStream);
+  });
+};
+

--- a/test/clock_test.js
+++ b/test/clock_test.js
@@ -1,0 +1,63 @@
+import assume from 'assume';
+import load from '../lib/main';
+
+suite('Clock', () => {
+  let clock;
+
+  before(async function () {
+    clock = await load('clock', {profile: 'test'});
+  });
+
+  after(() => {
+    // shut it all down!!!
+    clock._stop = true;
+  });
+
+  suite('msec', () =>  {
+    test('returns the current time', () => {
+      assume(clock.msec() - new Date()).is.lessThan(1000);
+    });
+  });
+
+  suite('setTimeout', () =>  {
+    test('sets a timeout', async () => {
+      let called = false;
+      clock.setTimeout('set called', () => called = true, 50);
+      assume(called).false();
+
+      await new Promise(resolve => setTimeout(resolve, 100)); // sleep 100ms
+
+      assume(called).true();
+    });
+
+    test('handles errors', async () => {
+      clock.setTimeout('crash', () => { throw new Error('uhoh'); }, 5);
+
+      await new Promise(resolve => setTimeout(resolve, 10)); // sleep 10ms
+    });
+
+    test('handles sync errors', async () => {
+      clock.setTimeout('crash', () => { throw new Error('uhoh'); }, 5);
+
+      await new Promise(resolve => setTimeout(resolve, 10)); // sleep 10ms
+    });
+
+    test('handles async errors', async () => {
+      clock.setTimeout('crash', async () => { throw new Error('uhoh'); }, 5);
+
+      await new Promise(resolve => setTimeout(resolve, 10)); // sleep 10ms
+    });
+  });
+
+  suite('periodically', () =>  {
+    test('runs a function periodically', async () => {
+      let calls = 0;
+      clock.periodically(10, 'inc', () => calls++);
+      assume(calls).equals(0);
+      await new Promise(resolve => setTimeout(resolve, 15)); // sleep 15ms
+      assume(calls).equals(1);
+      await new Promise(resolve => setTimeout(resolve, 10)); // sleep 10ms
+      assume(calls).equals(2);
+    });
+  });
+});

--- a/test/helper.js
+++ b/test/helper.js
@@ -59,6 +59,13 @@ class FakeClock {
     return this._msec;
   }
 
+  setTimeout (name, fn, delay) {
+    if (delay < 0) {
+      throw new Error('setTimeout called with a negative delay');
+    }
+    this._timers.push({name, fn, next: this._msec + when});
+  }
+
   periodically (interval, name, fn) {
     // note that, in testing, errors are fatal
     const run = async () => {
@@ -66,6 +73,11 @@ class FakeClock {
       this._timers.push({name, run, next: this._msec + interval});
     };
     this._timers.push({name, run, next: this._msec + interval});
+  }
+
+  throttle (fn) {
+    // for testing, do not apply throttling
+    return fn;
   }
 };
 

--- a/test/helper.js
+++ b/test/helper.js
@@ -3,8 +3,9 @@ import collectorManager from '../lib/collectormanager';
 import EventEmitter from 'events';
 import debugModule from 'debug';
 import assume from 'assume';
+import {Writable, Readable} from 'stream';
 
-class FakeQueue {
+export class FakeQueue {
   constructor () {
     this.statuses = {};
   }
@@ -27,18 +28,21 @@ class FakeQueue {
   }
 };
 
-class FakeClock {
+export class FakeClock {
   constructor () {
     this._msec = 1000000000;
     this._timers = [];
     this._debug = debugModule('FakeClock');
   }
 
-  // advance the fake clock..
+  // advance the fake clock, with some node ticks included
   async tick (msec) {
+    await new Promise(process.nextTick);
     const until = this._msec + msec;
 
     while (this._msec < until) {
+      await new Promise(process.nextTick);
+
       this._msec = this._timers.reduce((next, timer) => timer.next < next ? timer.next : next, until);
       this._debug(`${this._msec}: tick`);
 
@@ -46,7 +50,7 @@ class FakeClock {
       this._timers = [];
       await Promise.all(timers.map(async timer => {
         if (timer.next <= this._msec) {
-          this._debug(`${this._msec}: calling periodic function ${timer.name}`);
+          this._debug(`${this._msec}: calling function ${timer.name}`);
           await timer.run();
         } else {
           this._timers.push(timer);
@@ -63,7 +67,7 @@ class FakeClock {
     if (delay < 0) {
       throw new Error('setTimeout called with a negative delay');
     }
-    this._timers.push({name, fn, next: this._msec + when});
+    this._timers.push({name, run: fn, next: this._msec + delay});
   }
 
   periodically (interval, name, fn) {
@@ -78,6 +82,76 @@ class FakeClock {
   throttle (fn) {
     // for testing, do not apply throttling
     return fn;
+  }
+};
+
+export class FakeSignalFxRest {
+  constructor () {
+    this.datapoints = [];
+  }
+
+  fakeDatapoint (query, timestamp, value) {
+    if (!(query in this.datapoints)) {
+      this.datapoints[query] = [];
+    }
+    this.datapoints[query].push([timestamp, value]);
+  }
+
+  async timeserieswindow ({query, startMs, endMs, resolution}) {
+    if (!(query in this.datapoints)) {
+      throw new Error(`no fake datapoints for ${query}`);
+    }
+    return this.datapoints[query].filter(dp => dp[0] >= startMs && dp[0] <= endMs);
+  }
+};
+
+export class FakeIngest {
+  constructor () {
+    this.ingested = [];
+  }
+
+  send (req) {
+    this.ingested.push(req);
+  }
+};
+
+export class MetricStreamSource extends Readable {
+  constructor (clock) {
+    super({objectMode: true});
+    this.clock = clock;
+    this.on('error', console.error);
+    this.live = false;
+  }
+
+  sendAt (when, dp) {
+    const push = () => {
+      if (dp.live && !this.live) {
+        this.live = true;
+        this.emit('live');
+      }
+      this.emit('data', dp);
+    };
+
+    this.clock.setTimeout(`send datapoint ${JSON.stringify(dp)}`, push, when - this.clock.msec());
+  } 
+
+  _read () {
+    // prevent repeatedly calling this method
+    this.pause();
+  }
+};
+
+export class MetricStreamSink extends Writable {
+  constructor (clock) {
+    super({objectMode: true});
+    this.clock = clock;
+    this.received = [];
+    this.on('error', console.error);
+  }
+
+  _write (chunk, enc, next) {
+    this.received.push({received: this.clock.msec(), chunk});
+    next();
   }
 };
 

--- a/test/metricstream_test.js
+++ b/test/metricstream_test.js
@@ -1,0 +1,367 @@
+import assume from 'assume';
+import debugModule from 'debug';
+import {
+  FakeSignalFxRest,
+  FakeClock,
+  MetricStreamSource,
+  MetricStreamSink,
+  nextTick,
+  FakeIngest,
+} from './helper';
+import {
+  signalFxMetricStream,
+  metricLoggerStream,
+  signalFxIngester,
+  multiplexMetricStreams,
+} from '../lib/metricstream';
+
+const HOUR = 3600000;
+
+suite('metricstream', () => {
+  let fakes;
+  let sink;
+  let source;
+
+  beforeEach(async () => {
+    fakes = {};
+    fakes.signalFxRest = new FakeSignalFxRest();
+    fakes.clock = new FakeClock();
+
+    sink = new MetricStreamSink(fakes.clock);
+
+    source = new MetricStreamSource(fakes.clock);
+  });
+
+  suite('signalFxMetricStream', () => {
+    test('rejects invalid resolutions', () => {
+      try {
+        signalFxMetricStream({
+          query: 'sf_metric:foo',
+          resolution: 300000,
+          start: fakes.clock.msec(),
+          clock: fakes.clock,
+          signalFxRest: fakes.signalFxRest,
+        });
+      } catch (err) {
+        assume(err).matches(/invalid resolution/);
+        return;
+      }
+      throw new Error('no exception');
+    });
+
+    test('returns historical data, then emits "live"', async () => {
+      const start = fakes.clock.msec();
+      await fakes.clock.tick(4 * HOUR);
+
+      fakes.signalFxRest.fakeDatapoint('sf_metric:foo', start + HOUR * 0,   10);
+      fakes.signalFxRest.fakeDatapoint('sf_metric:foo', start + HOUR * 0.5, 15);
+      fakes.signalFxRest.fakeDatapoint('sf_metric:foo', start + HOUR * 1,   20);
+      fakes.signalFxRest.fakeDatapoint('sf_metric:foo', start + HOUR * 1.5, 25);
+      fakes.signalFxRest.fakeDatapoint('sf_metric:foo', start + HOUR * 2,   30);
+      fakes.signalFxRest.fakeDatapoint('sf_metric:foo', start + HOUR * 2.5, 35);
+      fakes.signalFxRest.fakeDatapoint('sf_metric:foo', start + HOUR * 3,   10);
+      fakes.signalFxRest.fakeDatapoint('sf_metric:foo', start + HOUR * 3.5, 15);
+
+      const stream = new signalFxMetricStream({
+        query: 'sf_metric:foo',
+        resolution: '1h',
+        start: start,
+        clock: fakes.clock,
+        signalFxRest: fakes.signalFxRest,
+      });
+      let live = false;
+      stream.on('live', () => live = true);
+      stream.on('error', err => console.error(err, err.stack));
+
+      stream.pipe(sink);
+
+      // tick until it goes live
+      while (!live) {
+        await fakes.clock.tick(0);
+      }
+
+      assume(sink.received).to.deeply.equal([
+        {received: 1014400000, chunk: {ts: start + HOUR * 0,   value: 10, live: false}},
+        {received: 1014400000, chunk: {ts: start + HOUR * 0.5, value: 15, live: false}},
+        {received: 1014400000, chunk: {ts: start + HOUR * 1,   value: 20, live: false}},
+        {received: 1014400000, chunk: {ts: start + HOUR * 1.5, value: 25, live: false}},
+        {received: 1014400000, chunk: {ts: start + HOUR * 2,   value: 30, live: false}},
+        {received: 1014400000, chunk: {ts: start + HOUR * 2.5, value: 35, live: false}},
+        {received: 1014400000, chunk: {ts: start + HOUR * 3,   value: 10, live: false}},
+        {received: 1014400000, chunk: {ts: start + HOUR * 3.5, value: 15, live: false}},
+      ]);
+    });
+
+    test('transitions from historical to live data', async () => {
+      // advance clock to the next even multiple of an hour
+      await fakes.clock.tick(HOUR - fakes.clock.msec() % HOUR);
+      const start = fakes.clock.msec();
+
+      fakes.clock.setTimeout('set datapoint at 0h',
+        () => fakes.signalFxRest.fakeDatapoint('sf_metric:foo', start + HOUR * 0, 10),
+        HOUR * 0 + 1000);
+      fakes.clock.setTimeout('set datapoint at 1h',
+        () => fakes.signalFxRest.fakeDatapoint('sf_metric:foo', start + HOUR * 1, 15),
+        HOUR * 1 + 500);
+      fakes.clock.setTimeout('set datapoint at 2h',
+        () => fakes.signalFxRest.fakeDatapoint('sf_metric:foo', start + HOUR * 2, 20),
+        HOUR * 2 + 450);
+      fakes.clock.setTimeout('set datapoint at 3h',
+        () => fakes.signalFxRest.fakeDatapoint('sf_metric:foo', start + HOUR * 3, 25),
+        HOUR * 3 + 550);
+      fakes.clock.setTimeout('set datapoint at 4h',
+        () => fakes.signalFxRest.fakeDatapoint('sf_metric:foo', start + HOUR * 4, 30),
+        HOUR * 4 + 550);
+
+      await fakes.clock.tick(HOUR);
+
+      const stream = new signalFxMetricStream({
+        query: 'sf_metric:foo',
+        resolution: '1h',
+        start: start,
+        clock: fakes.clock,
+        signalFxRest: fakes.signalFxRest,
+      });
+      let live = false;
+      stream.on('live', () => live = true);
+      stream.on('error', err => console.error(err, err.stack));
+
+      stream.pipe(sink);
+
+      // tick ahead, adding new datapoints as they arrive
+      await fakes.clock.tick(HOUR * 5);
+
+      const expected = [
+        {received: start + HOUR * 1,
+          chunk: {ts: start + HOUR * 0, value: 10, live: false}},
+        {received: start + HOUR * 2 + 15000, // 15000ms is QUANTIZER_DELAY
+          chunk: {ts: start + HOUR * 1, value: 15, live: true}},
+        {received: start + HOUR * 2 + 15000,
+          chunk: {ts: start + HOUR * 2, value: 20, live: true}},
+        {received: start + HOUR * 3 + 15000,
+          chunk: {ts: start + HOUR * 3, value: 25, live: true}},
+        {received: start + HOUR * 4 + 15000,
+          chunk: {ts: start + HOUR * 4, value: 30, live: true}},
+      ];
+
+      assume(sink.received).to.deeply.equal(expected);
+    });
+  });
+
+  suite('metricLoggerStream', () => {
+    test('logs datapoints and passes them through', async () => {
+      const logged = [];
+      source.sendAt(1000000500, {ts: 1000000000, value: 1, live: false});
+      source.sendAt(1000300400, {ts: 1000300000, value: 2, live: false});
+      source.sendAt(1000600450, {ts: 1000600000, value: 3, live: true});
+      source
+        .pipe(metricLoggerStream({prefix: 'pfx', log: (x) => logged.push(x), clock: fakes.clock}))
+        .pipe(sink);
+
+      await fakes.clock.tick(300000 * 4);
+
+      assume(logged).to.deeply.equal([
+        'pfx: ts=1000000000: 1 (historical)',
+        'pfx: ts=1000300000: 2 (historical)',
+        'pfx: ts=1000600000: 3 (live, 0.45s delay)',
+      ]);
+
+      assume(sink.received).to.deeply.equal([
+        {received: 1000000500, chunk: {ts: 1000000000, value: 1, live: false}},
+        {received: 1000300400, chunk: {ts: 1000300000, value: 2, live: false}},
+        {received: 1000600450, chunk: {ts: 1000600000, value: 3, live: true}},
+      ]);
+    });
+  });
+
+  suite('signalFxIngester', () => {
+    beforeEach(() => {
+      fakes.ingest = new FakeIngest();
+    });
+
+    test('throws an error on invalid types', () => {
+      try {
+        signalFxIngester({metric: 'foo.bar', type: 'knob', ingest: fakes.ingest});
+      } catch (err) {
+        assume(err).to.match(/Unknown metric type/);
+        return;
+      }
+      throw new Error('did not throw');
+    });
+
+    test('ingests datapoints and passes them through', async () => {
+      const logged = [];
+      source.sendAt(1000000500, {ts: 1000000000, value: 1, live: false});
+      source.sendAt(1000300400, {ts: 1000300000, value: 2, live: false});
+      source.sendAt(1000600450, {ts: 1000600000, value: 3, live: true});
+      source
+        .pipe(metricLoggerStream({clock: fakes.clock, log: debugModule('output')}))
+        .pipe(signalFxIngester({metric: 'foo.errors', type: 'gauge', ingest: fakes.ingest}))
+        .pipe(sink);
+
+      await fakes.clock.tick(300000 * 4);
+
+      assume(fakes.ingest.ingested).to.deeply.equal([
+        {gauges: [{metric: 'foo.errors', timestamp: 1000000000, value: 1}]},
+        {gauges: [{metric: 'foo.errors', timestamp: 1000300000, value: 2}]},
+        {gauges: [{metric: 'foo.errors', timestamp: 1000600000, value: 3}]},
+      ]);
+
+      assume(sink.received).to.deeply.equal([
+        {received: 1000000500, chunk: {ts: 1000000000, value: 1, live: false}},
+        {received: 1000300400, chunk: {ts: 1000300000, value: 2, live: false}},
+        {received: 1000600450, chunk: {ts: 1000600000, value: 3, live: true}},
+      ]);
+    });
+  });
+
+  suite('multiplexMetricStreams', () => {
+    let sources;
+    const setupSource = (src, sends) => {
+      sends.forEach(({at, ts, value, live}) => {
+        sources[src].stream.sendAt(at, {ts, value, live});
+      });
+    };
+
+    beforeEach(() => {
+      sources = [
+        {stream: new MetricStreamSource(fakes.clock), name: 'stream0'},
+        {stream: new MetricStreamSource(fakes.clock), name: 'stream1'},
+        {stream: new MetricStreamSource(fakes.clock), name: 'stream2'},
+      ];
+    });
+
+    test('multiplexes historical data, with missing values carried through from the last occurrence', async () => {
+      setupSource(0, [
+        {at: 1000180000, ts: 1000000000, value: 1, live: false},
+        {at: 1000180000, ts: 1000060000, value: 2, live: false},
+        {at: 1000180000, ts: 1000120000, value: 3, live: false},
+        {at: 1000180000, ts: 1000180000, value: 4, live: true},
+      ]);
+      setupSource(1, [
+        {at: 1000180000, ts: 1000060000, value: 22, live: false},
+        {at: 1000180000, ts: 1000180000, value: 24, live: true},
+      ]);
+
+      setupSource(2, [
+        {at: 1000180000, ts: 1000060000, value: 32, live: false},
+        {at: 1000180000, ts: 1000120000, value: 33, live: false},
+        {at: 1000180000, ts: 1000180000, value: 34, live: true},
+      ]);
+
+      multiplexMetricStreams({streams: sources, clock: fakes.clock})
+        .pipe(metricLoggerStream({clock: fakes.clock, log: debugModule('output')}))
+        .pipe(sink);
+
+      await fakes.clock.tick(190000);
+
+      assume(sink.received).to.deeply.equal([
+        {received: 1000180000, chunk: {ts: 1000000000, value: [1, undefined, undefined], live: false}},
+        {received: 1000180000, chunk: {ts: 1000060000, value: [2, 22, 32], live: false}},
+        {received: 1000180000, chunk: {ts: 1000120000, value: [3, 22, 33], live: false}},
+        // note 500ms delay is applied to this live datapoint:
+        {received: 1000180500, chunk: {ts: 1000180000, value: [4, 24, 34], live: true}},
+      ]);
+    });
+
+    test('delays live data consistently', async () => {
+      setupSource(0, [ // 500ms delay
+        {at: 1000600500, ts: 1000600000, value: 11, live: true},
+        {at: 1001200500, ts: 1001200000, value: 12, live: true},
+        {at: 1001800500, ts: 1001800000, value: 13, live: true},
+        {at: 1002400500, ts: 1002400000, value: 14, live: true},
+      ]);
+      setupSource(1, [ // 1500ms delay
+        {at: 1000601500, ts: 1000600000, value: 21, live: true},
+        {at: 1001201500, ts: 1001200000, value: 22, live: true},
+        {at: 1001801500, ts: 1001800000, value: 23, live: true},
+        {at: 1002401500, ts: 1002400000, value: 24, live: true},
+      ]);
+      setupSource(2, [ // 2000ms delay
+        {at: 1000602000, ts: 1000600000, value: 31, live: true},
+        {at: 1001202000, ts: 1001200000, value: 32, live: true},
+        {at: 1001802000, ts: 1001800000, value: 33, live: true},
+        {at: 1002402000, ts: 1002400000, value: 34, live: true},
+      ]);
+
+      multiplexMetricStreams({streams: sources, clock: fakes.clock})
+        .pipe(metricLoggerStream({clock: fakes.clock, log: debugModule('output')}))
+        .pipe(sink);
+
+      await fakes.clock.tick(3000000);
+
+      // applied delay is 2750 ms: 2000ms (max input delay) + 250ms (12.5%) + 500ms
+      assume(sink.received).to.deeply.equal([
+        {received: 1000602750, chunk: {ts: 1000600000, value: [11, 21, 31], live: true}},
+        {received: 1001202750, chunk: {ts: 1001200000, value: [12, 22, 32], live: true}},
+        {received: 1001802750, chunk: {ts: 1001800000, value: [13, 23, 33], live: true}},
+        {received: 1002402750, chunk: {ts: 1002400000, value: [14, 24, 34], live: true}},
+      ]);
+    });
+
+    test('starts when a stream goes live but never produces data', async () => {
+      // source 0 never produces data, but does eventually go "live", meaning if it ever does
+      // produce data it will be live
+      fakes.clock.setTimeout('stream 0 goes live', () => {
+        sources[0].stream.live = true;
+        sources[0].stream.emit('live');
+      }, 1000602200 - fakes.clock.msec());
+
+      setupSource(1, [ // 1500ms delay
+        {at: 1000601500, ts: 1000600000, value: 21, live: true},
+        {at: 1001201500, ts: 1001200000, value: 22, live: true},
+        {at: 1001801500, ts: 1001800000, value: 23, live: true},
+        {at: 1002401500, ts: 1002400000, value: 24, live: true},
+      ]);
+      setupSource(2, [
+        {at: 1000600500, ts: 1000600000, value: 31, live: true},
+        {at: 1001200500, ts: 1001200000, value: 32, live: true},
+        {at: 1001800500, ts: 1001800000, value: 33, live: true},
+        {at: 1002400500, ts: 1002400000, value: 34, live: true},
+      ]);
+
+      multiplexMetricStreams({streams: sources, clock: fakes.clock})
+        .pipe(metricLoggerStream({clock: fakes.clock, log: debugModule('output')}))
+        .pipe(sink);
+
+      await fakes.clock.tick(3000000);
+
+      assume(sink.received).to.deeply.equal([
+        // for the first tick, the multiplexer is still thinking things aren't live..
+        {received: 1000602200, chunk: {ts: 1000600000, value: [undefined, 21, 31], live: false}},
+        {received: 1001202187, chunk: {ts: 1001200000, value: [undefined, 22, 32], live: true}},
+        {received: 1001802187, chunk: {ts: 1001800000, value: [undefined, 23, 33], live: true}},
+        {received: 1002402187, chunk: {ts: 1002400000, value: [undefined, 24, 34], live: true}},
+      ]);
+    });
+
+    test('skips missing datapoints', async () => {
+      setupSource(0, [
+        {at: 1000600500, ts: 1000600000, value: 11, live: true},
+        {at: 1002400500, ts: 1002400000, value: 14, live: true},
+      ]);
+      setupSource(1, [
+        {at: 1001801500, ts: 1001800000, value: 23, live: true},
+        {at: 1002401500, ts: 1002400000, value: 24, live: true},
+      ]);
+      setupSource(2, [
+        {at: 1000602000, ts: 1000600000, value: 31, live: true},
+        {at: 1001802000, ts: 1001800000, value: 33, live: true},
+      ]);
+
+      multiplexMetricStreams({streams: sources, clock: fakes.clock})
+        .pipe(metricLoggerStream({clock: fakes.clock, log: debugModule('output')}))
+        .pipe(sink);
+
+      await fakes.clock.tick(3000000);
+
+      assume(sink.received).to.deeply.equal([
+        // note there are no datapoints at 120 seconds, so no output; furthermore, the stream
+        // is not live until 1001801500 when source 0 finally goes live
+        {received: 1001801500, chunk: {ts: 1000600000, value: [11, undefined, 31], live: false}},
+        {received: 1001802750, chunk: {ts: 1001800000, value: [11, 23, 33], live: true}},
+        {received: 1002402750, chunk: {ts: 1002400000, value: [14, 24, 33], live: true}},
+      ]);
+    });
+  });
+});

--- a/test/signalfx_test.js
+++ b/test/signalfx_test.js
@@ -1,0 +1,44 @@
+import assume from 'assume';
+import load from '../lib/main';
+import SignalFxRest from '../lib/signalfx-rest';
+
+suite('SignalFxRest', () => {
+  let rest;
+
+  before(async function () {
+    const cfg = await load('cfg', {profile: 'test'});
+    if (!cfg.signalfx.apiToken) {
+      this.skip();
+    }
+
+    rest = new SignalFxRest(cfg.signalfx.apiToken);
+  });
+
+  suite('timeserieswindow', async () => {
+    test('throws an error for a nonexistent metric', async () => {
+      let gotError;
+      await rest.timeserieswindow({
+        query: 'sf_metric:no.such.metric',
+        startMs: new Date() - 1000 * 3600 * 24,
+        endMs: new Date() - 1000 * 3600,
+        resolution: 1000 * 3600,
+      }).catch(err => gotError = err);
+      assume(gotError).inherits(Error);
+    });
+
+    test('returns a list of (timestamp, value) pairs for a demo metric', async () => {
+      let ts = await rest.timeserieswindow({
+        query: 'sf_metric:demo.trans.count AND demo_host:server6 ' +
+               'AND demo_customer:samslack.com AND demo_datacenter:Tokyo',
+        startMs: new Date() - 1000 * 3600 * 24,
+        endMs: new Date() - 1000 * 3600,
+        resolution: 1000 * 3600,
+      });
+      assume(ts).is.an('array');
+      assume(ts[0]).is.an('array');
+      assume(ts[0][0]).is.a('number');
+      assume(ts[0][1]).is.a('number');
+    });
+  });
+});
+

--- a/user-config-example.yml
+++ b/user-config-example.yml
@@ -1,4 +1,6 @@
 defaults:
+  signalfx:
+    apiToken: '...'
   pulse:
     username: '...'
     password: '...'


### PR DESCRIPTION
This is at the "proof of concept" stage.  I'd like to get it landed and running so we can start to stare at graphs.  Most of the action is on 5-minute and 1-hour timescales, so running it locally is a little boring.

SignalFx is kind of cranky, so I expect we'll find a lot of failure modes running this in production, and deal with those.

@imbstack we'll talk more about this next week, but the idea here is to provide a nice framework for defining all of the team's service levels.  Then we can put together a dashboard in the SignalFx UI to show us our error budgets, and look at that on at least a weekly basis (in production meetings).

The commits are well broken-out, if you'd like to read it that way.