### PR TITLE
Sink streams

### DIFF
--- a/src/collectormanager.js
+++ b/src/collectormanager.js
@@ -106,10 +106,10 @@ class CollectorManager extends EventEmitter {
     this.collectors.forEach(options => {
       components[options._fullname] = {
         requires: options.requires,
-        setup: dependencies => {
+        setup: async dependencies => {
           dependencies.debug = debug(options._fullname);
           dependencies.debug('setting up');
-          options._setup.call(dependencies);
+          await options._setup.call(dependencies);
           return dependencies;
         },
       };

--- a/src/metricstream.js
+++ b/src/metricstream.js
@@ -142,7 +142,7 @@ export const metricLoggerStream = ({prefix, log, clock}) => {
 };
 
 /**
- * A writeable stream that logs a metric stream directly to SignalFx.
+ * A through stream that logs a metric stream directly to SignalFx.
  *
  * options: {
  *   metric: // metric name
@@ -168,6 +168,17 @@ export const signalFxIngester = ({metric, type, ingest}) => {
       timestamp: chunk.ts,
     }];
     ingest.send(req);
+  });
+};
+
+/**
+ * A simple stream that sinks all data.  Use this to terminate a sequence
+ * of through streams.
+ */
+export const sinkStream = () => {
+  return new Writable({
+    objectMode: true,
+    write: (chunk, enc, next) => next(),
   });
 };
 

--- a/src/signalfx-rest.js
+++ b/src/signalfx-rest.js
@@ -41,7 +41,7 @@ export default class SignalFxRest {
     });
 
     if (res.statusCode != 200) {
-      throw new Error(`Error from signalfx: ${JSON.stringify(res.body)}`);
+      throw new Error(`Error from signalfx: HTTP ${res.statusCode}, ${JSON.stringify(res.body)}`);
     }
 
     // data is helpfully keyed by a random string, or more than one if there were


### PR DESCRIPTION
So, it turns out that a Transform stream (such as one from `sculpt.tap`) will buffer its output if it is not piped to anything, contrary to docs suggesting that it just drops that output.  The output buffer is 16 objects, so that meant most of the streams I created would process 16 datapoints and then stop.  Whoops.