### PR TITLE
Bug 1505405 - upgrade tc-lib-pulse

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "taskcluster-lib-docs": "^10.0.0",
     "taskcluster-lib-loader": "^10.0.1",
     "taskcluster-lib-monitor": "10.0.0",
-    "taskcluster-lib-pulse": "^2.0.8",
+    "taskcluster-lib-pulse": "^11.1.0",
     "taskcluster-lib-urls": "^10.0.0",
     "typed-env-config": "^2.0.0",
     "yargs": "^12.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3100,10 +3100,10 @@ taskcluster-lib-monitor@10.0.0:
     statsum "^0.6.0"
     taskcluster-client "^10.0.0"
 
-taskcluster-lib-pulse@^2.0.8:
-  version "2.0.8"
-  resolved "https://registry.yarnpkg.com/taskcluster-lib-pulse/-/taskcluster-lib-pulse-2.0.8.tgz#1f333d6e214834470116c3982fcbbeea95a0e2cd"
-  integrity sha512-+S2LiT41bEsNaEdsq5Tz2Cc3GGkgzpEltV/5ieCw6oPRuSwUc1qKuqZ7wILRmj75qW1q/b5FHp53nztS/IvKNA==
+taskcluster-lib-pulse@^11.1.0:
+  version "11.1.0"
+  resolved "https://registry.yarnpkg.com/taskcluster-lib-pulse/-/taskcluster-lib-pulse-11.1.0.tgz#bfcdbacbc70d0911b86f843e1a1b90649662cde0"
+  integrity sha512-L8dfCWWJtK3dAipQElOLsMCPiOFsnxzu0qwrQGJ3Qe4V//rxhRsdKsWYWPqejJ887qHTrQLVLMQi10MHY+WCvA==
   dependencies:
     amqplib "^0.5.2"
     aws-sdk "^2.331.0"


### PR DESCRIPTION
This service only consumes messages, so no need for a version ->
apiVersion change.